### PR TITLE
Improve website: fix typos, clean up resume page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # website
-Proffesional Website
+Professional Website

--- a/resume.html
+++ b/resume.html
@@ -16,56 +16,65 @@
     <a href="projects.html">Projects</a>
   </nav>
 
-  <h1>Søren Emil Skaarup</h1>
-  <p><a href="mailto:se.skaarup@gmail.com">se.skaarup@gmail.com</a> • Copenhagen, Denmark</p>
+  <p><a href="mailto:se.skaarup@gmail.com">se.skaarup@gmail.com</a> • 
+ Copenhagen, Denmark</p>
 
   <div class="section">
     <h2>Professional Summary</h2>
-    <p>Research Assistant in Machine Learning at FORCE Technology; associated with the Pioneer Centre for AI. Active in Danish Data Science Academy and Data Ethics Youth Board. Skilled in data analysis, teamwork, and English professional communication. :contentReference[oaicite:1]{index=1}</p>
+    <p>Research Assistant in Machine Learning at FORCE Technology; 
+associated with the Pioneer Centre for AI. Active in Danish Data Science Academy
+ and Data Ethics Youth Board. Skilled in data analysis, teamwork, and English 
+professional communication. </p>
   </div>
 
   <div class="section">
     <h2>Experience</h2>
     <h3>FORCE Technology – Research Assistant (Sep 2023–Present)</h3>
     <ul>
-      <li>Analyze industrial data using machine learning and statistical methods.</li>
+      <li>Analyze industrial data using machine learning and statistical 
+methods.</li>
     </ul>
 
     <h3>Pioneer Centre for AI – Associated Research (Feb 2024–Present)</h3>
     <ul>
-      <li>Contribute to interdisciplinary AI research projects. :contentReference[oaicite:2]{index=2}</li>
+      <li>Contribute to interdisciplinary AI research projects. 
+</li>
     </ul>
 
     <h3>Dataetisk Ungeråd – Associate (Oct 2024–Present)</h3>
     <ul>
-      <li>Engage in ethical discussions around emerging technologies like TikTok and ChatGPT.</li>
+      <li>Engage in ethical discussions around emerging technologies like 
+TikTok and ChatGPT.</li>
     </ul>
 
-    <h3>Danish Data Science Academy – Youth Advisory Board (Dec 2023–Present)</h3>
+    <h3>Danish Data Science Academy – Youth Advisory Board (Dec 
+2023–Present)</h3>
     <ul>
-      <li>Facilitate community and outreach efforts within the Danish data science landscape.</li>
+      <li>Facilitate community and outreach efforts within the Danish data 
+science landscape.</li>
     </ul>
 
-    <h3>Nordic Study Abroad Community – Admissions & Outreach (Jan–Dec 2023)</h3>
+    <h3>Nordic Study Abroad Community – Admissions & Outreach (Jan–Dec 
+2023)</h3>
     <ul><li>Managed communications for exchange students.</li></ul>
 
     <h3>Various Advisory/Board Roles & Teaching (2020–2023)</h3>
     <ul>
-      <li>Youth Advisory Board for CyberSkills project, JEF Europe political committee, European Youth Denmark, etc.</li>
+      <li>Youth Advisory Board for CyberSkills project, JEF Europe political
+ committee, European Youth Denmark, etc.</li>
     </ul>
 
     <h3>Military Service in The Royal Guard</h3>
     <ul>
-      <li>Military training for 4 months and guard service for 4 months.</li>
+      <li>Military training for 4 months and guard service for 4 
+months.</li>
     </ul>
-    
+
     <h3>Teaching Assistant at Dansborgskolen</h3>
     <ul>
       <li>Taught various levels for half a year.</li>
     </ul>
-    
-     
-    
+
   </div>
 
   <div class="section">
@@ -73,31 +82,38 @@
     <ul>
       <li>BSc Mathematics, Aarhus University (2023–2024)</li>
       <li>BSc Cognitive Science, Aarhus University (since Sept 2024)</li>
-      <li>High School Diploma in Further Mathematics & Social Science, Rysensteen Gymnasium (2018–2021)</li>
+      <li>High School Diploma in Further Mathematics & Social Science, 
+Rysensteen Gymnasium (2018–2021)</li>
     </ul>
   </div>
 
   <div class="section">
     <h2>Volunteer Work</h2>
     <ul>
-      <li>Social Work: Teaching Fugitives at Welcome House in Copenhagen, Coaching at Hvidovre Idrætsforening</li>
+      <li>Social Work: Teaching Fugitives at Welcome House in Copenhagen, 
+Coaching at Hvidovre Idrætsforening</li>
     </ul>
   </div>
 
   <div class="section">
     <h2>Skills & Certifications</h2>
     <ul>
-      <li>Languages: Danish (native), English (full professional), French (limited)</li>
-      <li>Training in Linux, cybersecurity, network scanning & surveillanceby prof. Jens Myrup at AAU</li>
-      <li>Awards: Winner of Niels Brock’s Stock Competition; participant in Projekt Forskerspirer (UCPH)</li>
+      <li>Languages: Danish (native), English (full professional), French 
+(limited)</li>
+      <li>Training in Linux, cybersecurity, network scanning & 
+surveillance by prof. Jens Myrup at AAU</li>
+      <li>Awards: Winner of Niels Brock’s Stock Competition; participant in 
+Projekt Forskerspirer (UCPH)</li>
     </ul>
   </div>
 
   <div class="section">
     <h2>Contact & Links</h2>
     <ul>
-      <li>Email: <a href="mailto:se.skaarup@gmail.com">se.skaarup@gmail.com</a></li>
-      <li><a href="https://www.linkedin.com/in/s%C3%B8ren-emil-skaarup-541557203">LinkedIn Profile</a></li>
+      <li>Email: <a 
+href="mailto:se.skaarup@gmail.com">se.skaarup@gmail.com</a></li>
+      <li><a href="https://www.linkedin.com/in/s%C3%B8ren-emil-
+skaarup-541557203">LinkedIn Profile</a></li>
     </ul>
   </div>
 </body>


### PR DESCRIPTION
This pull request improves the website by fixing typos and cleaning up the resume page. Changes include:

- Correct "Proffesional" to "Professional" in README.md.
- Remove duplicate heading in resume.html, remove stray citation macros, and fix spacing ("surveillance by").

These updates improve clarity and readability of the website pages.