### PR TITLE
Create reusable navigation partial

### DIFF
--- a/demos/Natural_History.html
+++ b/demos/Natural_History.html
@@ -10,11 +10,7 @@
   <h1>Natural History</h1>
 
   <!-- Navigation -->
-  <nav>
-    <a href="../index.html">Home</a>
-    <a href="../resume.html">Résumé</a>
-    <a href="../projects.html">Projects</a>
-  </nav>
+  <div data-include-nav data-nav-src="../partials/nav.html" data-nav-base=".."></div>
 
 
 
@@ -58,5 +54,6 @@
 
 
 
+  <script src="../js/nav.js" defer></script>
 </body>
 </html>

--- a/demos/ai-training-viz.html
+++ b/demos/ai-training-viz.html
@@ -8,11 +8,7 @@
 </head>
 <body>
   <h1>AI Training & Inference Demo</h1>
-  <nav>
-    <a href="../index.html">Home</a>
-    <a href="../resume.html">Résumé</a>
-    <a href="../projects.html">Projects</a>
-  </nav>
+  <div data-include-nav data-nav-src="../partials/nav.html" data-nav-base=".."></div>
 
   <p>Watch a model learn (error minimisation) and then generate text by sampling a multinomial distribution.</p>
 
@@ -20,6 +16,7 @@
   <canvas id="probCanvas"  style="width:100%;height:200px;"></canvas>
   <pre id="generatedText"></pre>
 
+  <script src="../js/nav.js" defer></script>
   <script type="module">
     import { startAIViz } from "../js/demos/modelTrainingDemo.js";
     startAIViz({

--- a/demos/bouncing-ball.html
+++ b/demos/bouncing-ball.html
@@ -10,17 +10,14 @@
   <h1>Bouncing-Ball Simulation</h1>
 
   <!-- Navigation back to projects list -->
-  <nav>
-    <a href="../index.html">Home</a>
-    <a href="../resume.html">Résumé</a>
-    <a href="../projects.html">Projects</a>
-  </nav>
+  <div data-include-nav data-nav-src="../partials/nav.html" data-nav-base=".."></div>
 
   <p>A minimal JavaScript canvas demo that shows a ball bouncing within the
      window. Resize your browser — it adapts automatically.</p>
 
   <canvas id="bouncingBall"></canvas>
 
+  <script src="../js/nav.js" defer></script>
   <!-- Load the demo logic -->
   <script type="module">
     import { startBouncing } from "../js/demos/bouncingBall.js";

--- a/demos/caesar-cipher.html
+++ b/demos/caesar-cipher.html
@@ -10,11 +10,7 @@
   <h1>Caesar Cipher Machine</h1>
 
   <!-- Navigation -->
-  <nav>
-    <a href="../index.html">Home</a>
-    <a href="../resume.html">Résumé</a>
-    <a href="../projects.html">Projects</a>
-  </nav>
+  <div data-include-nav data-nav-src="../partials/nav.html" data-nav-base=".."></div>
 
   <p>Choose a key (0–25), paste text, and encrypt or decrypt using a classic Caesar shift.</p>
 
@@ -34,6 +30,7 @@
   <h3>Output</h3>
   <textarea id="cipherText" rows="4" style="width:100%;" readonly></textarea>
 
+  <script src="../js/nav.js" defer></script>
   <script type="module">
     import { setupCaesar } from "../js/demos/caesarCipher.js";
     setupCaesar({

--- a/demos/entropy-bio-simulator.html
+++ b/demos/entropy-bio-simulator.html
@@ -9,17 +9,14 @@
 <body>
   <h1>Entropy Bio-Simulator</h1>
 
-  <nav>
-    <a href="../index.html">Home</a>
-    <a href="../resume.html">Résumé</a>
-    <a href="../projects.html">Projects</a>
-  </nav>
+  <div data-include-nav data-nav-src="../partials/nav.html" data-nav-base=".."></div>
 
   <p>A three-state cellular automaton illustrating energy flow, reproduction,
      and entropy growth.</p>
 
   <canvas id="entropySim"></canvas>
 
+  <script src="../js/nav.js" defer></script>
   <script type="module">
     import { startEntropySim } from "../js/demos/entropyBioSimulator.js";
     startEntropySim("entropySim");

--- a/demos/nitrogen-cycle.html
+++ b/demos/nitrogen-cycle.html
@@ -9,17 +9,14 @@
 <body>
   <h1>Nitrogen Cycle Visualizer</h1>
 
-  <nav>
-    <a href="../index.html">Home</a>
-    <a href="../resume.html">Résumé</a>
-    <a href="../projects.html">Projects</a>
-  </nav>
+  <div data-include-nav data-nav-src="../partials/nav.html" data-nav-base=".."></div>
 
   <p>Animated diagram of the key processes in the nitrogen cycle.</p>
 
   <!-- The canvas auto-scales with CSS; 600×400 default -->
   <canvas id="nitrogenCanvas" style="width:100%;height:400px;"></canvas>
 
+  <script src="../js/nav.js" defer></script>
   <script type="module">
     import { startNitrogenCycle } from "../js/demos/nitrogenCycle.js";
     startNitrogenCycle("nitrogenCanvas");

--- a/demos/physics.html
+++ b/demos/physics.html
@@ -10,11 +10,7 @@
   <h1>Physics</h1>
 
   <!-- Navigation -->
-  <nav>
-    <a href="../index.html">Home</a>
-    <a href="../resume.html">Résumé</a>
-    <a href="../projects.html">Projects</a>
-  </nav>
+  <div data-include-nav data-nav-src="../partials/nav.html" data-nav-base=".."></div>
 
 <h1>Physics Fundamentals</h1>
 
@@ -49,5 +45,6 @@
   </p>
 
 
+  <script src="../js/nav.js" defer></script>
 </body>
 </html>

--- a/demos/starfield.html
+++ b/demos/starfield.html
@@ -10,16 +10,13 @@
   <h1>Starfield Animation</h1>
 
   <!-- Navigation -->
-  <nav>
-    <a href="../index.html">Home</a>
-    <a href="../resume.html">Résumé</a>
-    <a href="../projects.html">Projects</a>
-  </nav>
+  <div data-include-nav data-nav-src="../partials/nav.html" data-nav-base=".."></div>
 
   <p>Enjoy the retro space-warp effect! (Auto-resizes on window changes.)</p>
 
   <canvas id="starfield"></canvas>
 
+  <script src="../js/nav.js" defer></script>
   <script type="module">
     import { startStarfield } from "../js/demos/starfield.js";
     startStarfield("starfield");

--- a/demos/stat-intuition.html
+++ b/demos/stat-intuition.html
@@ -9,14 +9,11 @@
 </head>
 <body>
   <h1>Statistical Intuition Game</h1>
-  <nav>
-    <a href="../index.html">Home</a>
-    <a href="../resume.html">Résumé</a>
-    <a href="../projects.html">Projects</a>
-  </nav>
+  <div data-include-nav data-nav-src="../partials/nav.html" data-nav-base=".."></div>
 
   <div id="statGame"></div>
 
+  <script src="../js/nav.js" defer></script>
   <script src="../js/demos/statIntuitionGame.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -10,11 +10,7 @@
   <h1>Søren Emil Skaarup</h1>
 
   <!-- Navigation -->
-  <nav>
-    <a href="index.html">Home</a>
-    <a href="resume.html">Résumé</a>
-    <a href="projects.html">Projects</a>
-  </nav>
+  <div data-include-nav data-nav-src="partials/nav.html" data-nav-base="."></div>
 
   <p>Welcome to my personal website. This is a central place for my projects, research, and digital experiments. You'll find links to my résumé, ongoing work, and small interactive demos here.</p>
 
@@ -27,6 +23,7 @@
     <h2><a href="projects.html">Projects</a></h2>
     <p>A mix of public and private projects. This section will also host live demos of small games and simulations built in JavaScript.</p>
   </div>
+  <script src="js/nav.js" defer></script>
 </body>
 </html>
 

--- a/js/nav.js
+++ b/js/nav.js
@@ -1,0 +1,40 @@
+async function injectNav(placeholder) {
+  const src = placeholder.getAttribute('data-nav-src') || 'partials/nav.html';
+  const base = placeholder.getAttribute('data-nav-base') || '.';
+  try {
+    const response = await fetch(src);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch navigation from ${src}`);
+    }
+    const html = await response.text();
+    placeholder.innerHTML = html;
+
+    const nav = placeholder.querySelector('nav');
+    if (nav) {
+      const normalizedBase = base === '.' ? '' : base.replace(/\/$/, '') + '/';
+      nav.querySelectorAll('a[data-href]').forEach((link) => {
+        const target = link.getAttribute('data-href');
+        if (!target) {
+          return;
+        }
+        const fullPath = `${normalizedBase}${target}`.replace(/\/\/+/, '/');
+        link.setAttribute('href', fullPath);
+      });
+    }
+  } catch (error) {
+    console.error(error);
+  }
+}
+
+function initNavInjection() {
+  const placeholders = document.querySelectorAll('[data-include-nav]');
+  placeholders.forEach((placeholder) => {
+    injectNav(placeholder);
+  });
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initNavInjection);
+} else {
+  initNavInjection();
+}

--- a/partials/nav.html
+++ b/partials/nav.html
@@ -1,0 +1,5 @@
+<nav class="site-nav">
+  <a href="index.html" data-href="index.html">Home</a>
+  <a href="resume.html" data-href="resume.html">Résumé</a>
+  <a href="projects.html" data-href="projects.html">Projects</a>
+</nav>

--- a/projects.html
+++ b/projects.html
@@ -10,11 +10,7 @@
   <h1>Projects</h1>
 
   <!-- Navigation -->
-  <nav>
-    <a href="index.html">Home</a>
-    <a href="resume.html">Résumé</a>
-    <a href="projects.html">Projects</a>
-  </nav>
+  <div data-include-nav data-nav-src="partials/nav.html" data-nav-base="."></div>
 
   <p>This page lists my ongoing research, side projects, and interactive demos.  
      Click any demo to open it on its own clean page.</p>
@@ -65,5 +61,6 @@
 
 
   </div>
+  <script src="js/nav.js" defer></script>
 </body>
 </html>

--- a/resume.html
+++ b/resume.html
@@ -10,11 +10,7 @@
   <h1>Søren Emil Skaarup</h1>
 
   <!-- Navigation -->
-  <nav>
-    <a href="index.html">Home</a>
-    <a href="resume.html">Résumé</a>
-    <a href="projects.html">Projects</a>
-  </nav>
+  <div data-include-nav data-nav-src="partials/nav.html" data-nav-base="."></div>
 
   <p><a href="mailto:se.skaarup@gmail.com">se.skaarup@gmail.com</a> • 
  Copenhagen, Denmark</p>
@@ -116,5 +112,6 @@ href="mailto:se.skaarup@gmail.com">se.skaarup@gmail.com</a></li>
 skaarup-541557203">LinkedIn Profile</a></li>
     </ul>
   </div>
+  <script src="js/nav.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a reusable `partials/nav.html` file plus a lightweight loader script so the navigation markup is defined in just one place
- replace the hard-coded `<nav>` blocks in every page (including all demos) with the new placeholder that loads the shared navigation

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919d485ee588321926c417d4dcba198)