### PR TITLE
Revamp site homepage and projects showcase

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,15 +1,21 @@
 /* Global layout */
 body {
   font-family: sans-serif;
-  max-width: 800px;
+  max-width: 960px;
   margin: 0 auto;
   padding: 2em;
   line-height: 1.6;
+  background: #f7f8fb;
+  color: #1f2933;
+}
+
+.page-title {
+  margin-top: 0.2em;
 }
 
 /* Headings */
 h1, h2, h3 {
-  border-bottom: 1px solid #ccc;
+  border-bottom: 1px solid #dfe3eb;
   padding-bottom: 0.3em;
 }
 
@@ -36,9 +42,196 @@ a:hover {
   text-decoration: underline;
 }
 
+/* Buttons */
+.button {
+  display: inline-block;
+  padding: 0.65em 1.1em;
+  border-radius: 8px;
+  border: 1px solid #d0d7e2;
+  background: #fff;
+  color: #0645AD;
+  font-weight: 700;
+  margin-right: 0.5em;
+  margin-top: 0.4em;
+}
+.button.primary {
+  background: linear-gradient(135deg, #0645AD, #3b82f6);
+  color: #fff;
+  border: none;
+  box-shadow: 0 8px 20px rgba(6, 69, 173, 0.2);
+}
+.button.ghost {
+  background: transparent;
+}
+.button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+}
+
+.cta-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
 /* Section spacing */
 .section {
+  margin-bottom: 2.4em;
+  background: #fff;
+  padding: 1.5em;
+  border-radius: 12px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.05);
+}
+.section.accent {
+  background: linear-gradient(135deg, #eef2ff, #f7f8fb);
+  box-shadow: none;
+  border: 1px solid #e0e6f3;
+}
+
+/* Hero */
+.hero {
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  gap: 1.4em;
+  align-items: center;
+  background: linear-gradient(135deg, #0a3d91, #1d4ed8);
+  color: #eef3ff;
+  padding: 1.8em;
+  border-radius: 14px;
   margin-bottom: 2em;
+  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.15);
+}
+.hero .eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  margin: 0 0 0.5em 0;
+  color: #c7ddff;
+}
+.hero h2 {
+  border: none;
+  padding: 0;
+  margin: 0 0 0.6em 0;
+  font-size: 1.8rem;
+}
+.hero p {
+  margin-top: 0;
+  margin-bottom: 0.6em;
+}
+.hero a {
+  color: #fff;
+}
+.hero .hero-card {
+  background: rgba(255, 255, 255, 0.12);
+  border: 1px solid rgba(255, 255, 255, 0.24);
+  border-radius: 12px;
+  padding: 1em;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.18);
+}
+.hero .hero-card h3 {
+  border: none;
+  padding: 0;
+  margin-top: 0;
+  margin-bottom: 0.4em;
+}
+
+/* Layout helpers */
+.grid.two-col {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.2em;
+}
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1em;
+}
+
+.card {
+  background: #fff;
+  border: 1px solid #e4e8ef;
+  border-radius: 12px;
+  padding: 1em;
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.04);
+}
+.card h3 {
+  border: none;
+  padding: 0;
+  margin-top: 0;
+}
+.label {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  color: #52616b;
+  margin: 0 0 0.4em 0;
+}
+
+/* Lists */
+ul {
+  margin-left: 1em;
+  list-style-type: disc;
+}
+.compact-list {
+  list-style: none;
+  padding-left: 0;
+  margin: 0;
+}
+.compact-list li {
+  margin: 0.3em 0;
+}
+.pill-list {
+  list-style: none;
+  padding: 0;
+  margin: 0.6em 0 0 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4em;
+}
+.pill-list li {
+  background: #eef2ff;
+  border-radius: 999px;
+  padding: 0.35em 0.75em;
+  font-size: 0.9rem;
+  color: #1f2a44;
+}
+.stacked-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+.stacked-list li {
+  background: #fff;
+  border: 1px solid #e4e8ef;
+  border-radius: 10px;
+  padding: 0.8em;
+  margin-bottom: 0.6em;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.03);
+}
+
+/* Timeline */
+.timeline {
+  border-left: 3px solid #cdd6ee;
+  padding-left: 1.2em;
+}
+.timeline-item {
+  position: relative;
+  margin-bottom: 1em;
+}
+.timeline-item .dot {
+  position: absolute;
+  left: -1.56em;
+  top: 0.35em;
+  width: 12px;
+  height: 12px;
+  background: #3b82f6;
+  border-radius: 50%;
+  box-shadow: 0 0 0 4px #e6ecfa;
+}
+.timeline-item h3 {
+  border: none;
+  padding: 0;
+  margin: 0 0 0.3em 0;
 }
 
 /* Demo areas */
@@ -49,8 +242,12 @@ canvas {
   border: 1px solid #ccc;
 }
 
-/* Lists */
-ul {
-  margin-left: 1em;
-  list-style-type: disc;
+/* Responsive tweaks */
+@media (max-width: 720px) {
+  body {
+    padding: 1.4em;
+  }
+  .hero {
+    grid-template-columns: 1fr;
+  }
 }

--- a/index.html
+++ b/index.html
@@ -7,23 +7,126 @@
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
-  <h1>Søren Emil Skaarup</h1>
+  <h1 class="page-title">Søren Emil Skaarup</h1>
 
   <!-- Navigation -->
   <div data-include-nav data-nav-src="partials/nav.html" data-nav-base="."></div>
 
-  <p>Welcome to my personal website. This is a central place for my projects, research, and digital experiments. You'll find links to my résumé, ongoing work, and small interactive demos here.</p>
+  <section class="hero">
+    <div>
+      <p class="eyebrow">Machine Learning • Data Ethics • Cognitive Science</p>
+      <h2>Researcher exploring human-centered AI and creative simulations.</h2>
+      <p>I build demos to make abstract ideas tangible—whether that's ethics in AI,
+         emergent behaviour, or playful statistical intuition. This site is my
+         living lab: equal parts resume, research log, and gallery of quick experiments.</p>
+      <div class="cta-row">
+        <a class="button primary" href="projects.html">See projects</a>
+        <a class="button" href="resume.html">Résumé</a>
+        <a class="button ghost" href="mailto:se.skaarup@gmail.com">Email me</a>
+      </div>
+    </div>
+    <div class="hero-card">
+      <h3>Now</h3>
+      <ul class="compact-list">
+        <li><strong>Reading:</strong> Cognitive architectures for responsible AI.</li>
+        <li><strong>Building:</strong> Tiny simulations that explain entropy and probability.</li>
+        <li><strong>Location:</strong> Copenhagen, Denmark.</li>
+      </ul>
+    </div>
+  </section>
 
-  <div class="section">
-    <h2><a href="resume.html">Résumé</a></h2>
-    <p>Summary of my professional experience, based on my LinkedIn profile.</p>
-  </div>
+  <section class="section">
+    <h2>Highlights</h2>
+    <div class="card-grid">
+      <article class="card">
+        <p class="label">Current focus</p>
+        <h3>Research Assistant, FORCE Technology</h3>
+        <p>Working on industrial machine learning with an emphasis on trustworthy
+           systems and explainability. Collaborating with the Pioneer Centre for AI</p>
+        <ul class="pill-list">
+          <li>Model auditing</li>
+          <li>Signal analysis</li>
+          <li>Human-in-the-loop design</li>
+        </ul>
+      </article>
+      <article class="card">
+        <p class="label">Community</p>
+        <h3>Data Ethics & Youth Advisory</h3>
+        <p>Active voice in the Danish data science scene and youth boards discussing
+           how platforms like TikTok and generative models shape society.</p>
+        <ul class="pill-list">
+          <li>Data Ethics Youth Board</li>
+          <li>Danish Data Science Academy</li>
+          <li>Workshops & outreach</li>
+        </ul>
+      </article>
+      <article class="card">
+        <p class="label">Playground</p>
+        <h3>Interactive Experiments</h3>
+        <p>Short demos that invite exploration—games, visual explanations, and
+           micro essays where code and writing meet.</p>
+        <ul class="pill-list">
+          <li><a href="projects.html#demos">Demo gallery</a></li>
+          <li><a href="demos/ai-training-viz.html">AI training viz</a></li>
+          <li><a href="demos/entropy-bio-simulator.html">Entropy automaton</a></li>
+        </ul>
+      </article>
+    </div>
+  </section>
 
-  <div class="section">
-    <h2><a href="projects.html">Projects</a></h2>
-    <p>A mix of public and private projects. This section will also host live demos of small games and simulations built in JavaScript.</p>
-  </div>
+  <section class="section">
+    <h2>Fresh from the Lab</h2>
+    <div class="timeline">
+      <div class="timeline-item">
+        <div class="dot"></div>
+        <div>
+          <h3>Statistical intuition mini-course</h3>
+          <p>An experiment in teaching Bayesian thinking through short levels and
+             playful feedback. Inspired by common pitfalls I see in data ethics debates.</p>
+          <a href="demos/stat-intuition.html">Open the interactive lesson →</a>
+        </div>
+      </div>
+      <div class="timeline-item">
+        <div class="dot"></div>
+        <div>
+          <h3>AI training visualiser</h3>
+          <p>Watch loss curves and sample evolution as a simple model learns. Designed
+             to demystify what happens between "train" and "deploy".</p>
+          <a href="demos/ai-training-viz.html">Run the visualiser →</a>
+        </div>
+      </div>
+      <div class="timeline-item">
+        <div class="dot"></div>
+        <div>
+          <h3>Entropy Bio-Simulator</h3>
+          <p>A cellular automaton exploring resource competition, randomness, and
+             resilience. Great for sparking conversations about complex systems.</p>
+          <a href="demos/entropy-bio-simulator.html">Explore the simulator →</a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="section accent">
+    <h2>What I'm interested in</h2>
+    <div class="grid two-col">
+      <div>
+        <h3>Questions</h3>
+        <ul class="compact-list">
+          <li>How do we make AI systems accountable without stifling creativity?</li>
+          <li>Which visual metaphors make statistics feel intuitive to newcomers?</li>
+          <li>What can small, playful simulations teach about policy and ethics?</li>
+        </ul>
+      </div>
+      <div>
+        <h3>Collaborations</h3>
+        <p>If you're working on interpretable ML, ethical product design, or science
+           communication, I'm always happy to trade notes.</p>
+        <a class="button primary" href="mailto:se.skaarup@gmail.com">Start a conversation</a>
+      </div>
+    </div>
+  </section>
+
   <script src="js/nav.js" defer></script>
 </body>
 </html>
-

--- a/projects.html
+++ b/projects.html
@@ -12,55 +12,127 @@
   <!-- Navigation -->
   <div data-include-nav data-nav-src="partials/nav.html" data-nav-base="."></div>
 
-  <p>This page lists my ongoing research, side projects, and interactive demos.  
-     Click any demo to open it on its own clean page.</p>
+  <p>This page captures what I'm building and researching. Some items are polished,
+     others are living sketches I iterate on in public.</p>
 
+  <section class="section">
+    <h2>Feature Projects</h2>
+    <div class="card-grid">
+      <article class="card">
+        <p class="label">Applied ML</p>
+        <h3>Industrial ML &amp; Signal Analysis</h3>
+        <p>Practical machine learning at FORCE Technology with a focus on robust
+           pipelines, anomaly detection, and explainability. Many insights feed into my
+           teaching and demos.</p>
+        <ul class="pill-list">
+          <li>Trustworthy AI</li>
+          <li>Edge constraints</li>
+          <li>Experiment design</li>
+        </ul>
+      </article>
+      <article class="card">
+        <p class="label">Communication</p>
+        <h3>Data Ethics Workshops</h3>
+        <p>Hands-on sessions for students and practitioners exploring how algorithms
+           shape behaviour. Uses stories and interactive examples to make complex
+           trade-offs tangible.</p>
+        <ul class="pill-list">
+          <li>Platform dynamics</li>
+          <li>Design for agency</li>
+          <li>Participatory methods</li>
+        </ul>
+      </article>
+      <article class="card">
+        <p class="label">Learning tools</p>
+        <h3>Statistical Intuition Game</h3>
+        <p>Playable micro-lessons that guide people through correlation pitfalls and
+           Bayesian thinking. Built to make maths feel less intimidating and more
+           exploratory.</p>
+        <a href="demos/stat-intuition.html">Try the demo →</a>
+      </article>
+    </div>
+  </section>
 
-  <div class="section">
+  <section class="section" id="demos">
     <h2>Interactive Demos</h2>
-    <ul>
-  <li>
-    <strong>Bouncing-Ball Simulation</strong> – Basic physics loop in Canvas.
-    <a href="demos/bouncing-ball.html">View demo →</a>
-  </li>
-  <li>
-    <strong>Starfield Animation</strong> – Retro flying-through-space effect.
-    <a href="demos/starfield.html">View demo →</a>
-  </li>
-  <li>
-    <strong>Essay</strong> – Physics
-    <a href="demos/physics.html">View →</a>
-  </li>
-  <li>
-    <strong>Essay</strong> – Natural History
-    <a href="demos/Natural_History.html">View →</a>
-  </li>
-  <li>
-  <strong>Entropy Bio-Simulator</strong> – Cellular automaton of life, resources, and entropy.
-  <a href="demos/entropy-bio-simulator.html">View demo →</a>
-  </li>
-  <li>
-  <strong>Nitrogen Cycle Visualizer</strong> – Animated diagram of nitrogen flows.
-  <a href="demos/nitrogen-cycle.html">View demo →</a>
-  </li>
-  <li>
-  <strong>Caesar Cipher Machine</strong> – Encrypt or decrypt text by a chosen shift.
-  <a href="demos/caesar-cipher.html">View demo →</a>
-  </li>
-  <li>
-  <strong>Statistical Intuition Game</strong> – Hands-on lessons on correlation, causation, Bayesian pitfalls.
-  <a href="demos/stat-intuition.html">View demo →</a>
-  </li>
-  <li>
-  <strong>AI Training &amp; Inference Demo</strong> – Watch error minimisation and multinomial sampling.
-  <a href="demos/ai-training-viz.html">View demo →</a>
-  </li>
+    <p>Short, self-contained experiments that often accompany talks or essays.</p>
+    <div class="grid two-col">
+      <ul class="stacked-list">
+        <li>
+          <strong>Bouncing-Ball Simulation</strong> — Basic physics loop in Canvas.
+          <a href="demos/bouncing-ball.html">View demo →</a>
+        </li>
+        <li>
+          <strong>Starfield Animation</strong> — Retro flying-through-space effect.
+          <a href="demos/starfield.html">View demo →</a>
+        </li>
+        <li>
+          <strong>Entropy Bio-Simulator</strong> — Cellular automaton of life, resources,
+          and entropy.
+          <a href="demos/entropy-bio-simulator.html">View demo →</a>
+        </li>
+        <li>
+          <strong>Nitrogen Cycle Visualizer</strong> — Animated diagram of nitrogen flows.
+          <a href="demos/nitrogen-cycle.html">View demo →</a>
+        </li>
+        <li>
+          <strong>Caesar Cipher Machine</strong> — Encrypt or decrypt text by a chosen shift.
+          <a href="demos/caesar-cipher.html">View demo →</a>
+        </li>
+      </ul>
+      <ul class="stacked-list">
+        <li>
+          <strong>AI Training &amp; Inference Demo</strong> — Watch error minimisation and
+          multinomial sampling.
+          <a href="demos/ai-training-viz.html">View demo →</a>
+        </li>
+        <li>
+          <strong>Statistical Intuition Game</strong> — Hands-on lessons on correlation,
+          causation, Bayesian pitfalls.
+          <a href="demos/stat-intuition.html">View demo →</a>
+        </li>
+        <li>
+          <strong>Essay</strong> — Physics
+          <a href="demos/physics.html">View →</a>
+        </li>
+        <li>
+          <strong>Essay</strong> — Natural History
+          <a href="demos/Natural_History.html">View →</a>
+        </li>
+      </ul>
+    </div>
+  </section>
 
+  <section class="section accent">
+    <h2>Research Snapshots</h2>
+    <div class="timeline">
+      <div class="timeline-item">
+        <div class="dot"></div>
+        <div>
+          <h3>Interpretable pipelines</h3>
+          <p>Documenting simple heuristics for auditing industrial ML systems so that
+             engineers and non-technical partners can co-own model decisions.</p>
+        </div>
+      </div>
+      <div class="timeline-item">
+        <div class="dot"></div>
+        <div>
+          <h3>Ethics in motion</h3>
+          <p>Using agent-based demos to show how platform incentives nudge behaviour,
+             drawing from my work on youth advisory boards.</p>
+        </div>
+      </div>
+      <div class="timeline-item">
+        <div class="dot"></div>
+        <div>
+          <h3>Learning from small data</h3>
+          <p>Exploring Bayesian and simulation-based techniques to extract signal when
+             datasets are thin, noisy, or privacy constrained.</p>
+        </div>
+      </div>
+    </div>
+  </section>
 
-</ul>
-
-
-  </div>
   <script src="js/nav.js" defer></script>
 </body>
 </html>

--- a/resume.html
+++ b/resume.html
@@ -7,63 +7,70 @@
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
-  <h1>Søren Emil Skaarup</h1>
+  <h1 class="page-title">Søren Emil Skaarup</h1>
 
   <!-- Navigation -->
   <div data-include-nav data-nav-src="partials/nav.html" data-nav-base="."></div>
 
-  <p><a href="mailto:se.skaarup@gmail.com">se.skaarup@gmail.com</a> • 
- Copenhagen, Denmark</p>
+  <p><a href="mailto:se.skaarup@gmail.com">se.skaarup@gmail.com</a> • Copenhagen, Denmark</p>
 
   <div class="section">
     <h2>Professional Summary</h2>
-    <p>Research Assistant in Machine Learning at FORCE Technology; 
-associated with the Pioneer Centre for AI. Active in Danish Data Science Academy
- and Data Ethics Youth Board. Skilled in data analysis, teamwork, and English 
-professional communication. </p>
+    <p>Research Assistant in Machine Learning at FORCE Technology; associated with the Pioneer Centre for AI. Active in Danish Data Science Academy and Data Ethics Youth Board. Skilled in data analysis, teamwork, and English professional communication.</p>
+    <div class="card-grid">
+      <article class="card">
+        <p class="label">Impact</p>
+        <h3>Trusted AI, explained</h3>
+        <p>Translating ML work into stories and visuals so domain experts can audit models with confidence.</p>
+      </article>
+      <article class="card">
+        <p class="label">Leadership</p>
+        <h3>Community builder</h3>
+        <p>Facilitating youth advisory groups and workshops on data ethics and algorithmic accountability.</p>
+      </article>
+      <article class="card">
+        <p class="label">Maker</p>
+        <h3>Prototype mindset</h3>
+        <p>Designing quick simulations to test ideas before they become full-scale products or policies.</p>
+      </article>
+    </div>
   </div>
 
   <div class="section">
     <h2>Experience</h2>
     <h3>FORCE Technology – Research Assistant (Sep 2023–Present)</h3>
     <ul>
-      <li>Analyze industrial data using machine learning and statistical 
-methods.</li>
+      <li>Analyze industrial data using machine learning and statistical methods.</li>
     </ul>
 
     <h3>Pioneer Centre for AI – Associated Research (Feb 2024–Present)</h3>
     <ul>
-      <li>Contribute to interdisciplinary AI research projects. 
-</li>
+      <li>Contribute to interdisciplinary AI research projects.</li>
     </ul>
 
     <h3>Dataetisk Ungeråd – Associate (Oct 2024–Present)</h3>
     <ul>
-      <li>Engage in ethical discussions around emerging technologies like 
-TikTok and ChatGPT.</li>
+      <li>Engage in ethical discussions around emerging technologies like TikTok and ChatGPT.</li>
     </ul>
 
-    <h3>Danish Data Science Academy – Youth Advisory Board (Dec 
-2023–Present)</h3>
+    <h3>Danish Data Science Academy – Youth Advisory Board (Dec 2023–Present)</h3>
     <ul>
-      <li>Facilitate community and outreach efforts within the Danish data 
-science landscape.</li>
+      <li>Facilitate community and outreach efforts within the Danish data science landscape.</li>
     </ul>
 
-    <h3>Nordic Study Abroad Community – Admissions & Outreach (Jan–Dec 
-2023)</h3>
-    <ul><li>Managed communications for exchange students.</li></ul>
+    <h3>Nordic Study Abroad Community – Admissions & Outreach (Jan–Dec 2023)</h3>
+    <ul>
+      <li>Managed communications for exchange students.</li>
+    </ul>
 
     <h3>Various Advisory/Board Roles & Teaching (2020–2023)</h3>
     <ul>
-      <li>Youth Advisory Board for CyberSkills project, JEF Europe political
- committee, European Youth Denmark, etc.</li>
+      <li>Youth Advisory Board for CyberSkills project, JEF Europe political committee, European Youth Denmark, etc.</li>
     </ul>
 
     <h3>Military Service in The Royal Guard</h3>
     <ul>
-      <li>Military training for 4 months and guard service for 4 
-months.</li>
+      <li>Military training for 4 months and guard service for 4 months.</li>
     </ul>
 
     <h3>Teaching Assistant at Dansborgskolen</h3>
@@ -78,38 +85,31 @@ months.</li>
     <ul>
       <li>BSc Mathematics, Aarhus University (2023–2024)</li>
       <li>BSc Cognitive Science, Aarhus University (since Sept 2024)</li>
-      <li>High School Diploma in Further Mathematics & Social Science, 
-Rysensteen Gymnasium (2018–2021)</li>
+      <li>High School Diploma in Further Mathematics & Social Science, Rysensteen Gymnasium (2018–2021)</li>
     </ul>
   </div>
 
   <div class="section">
     <h2>Volunteer Work</h2>
     <ul>
-      <li>Social Work: Teaching Fugitives at Welcome House in Copenhagen, 
-Coaching at Hvidovre Idrætsforening</li>
+      <li>Social Work: Teaching Fugitives at Welcome House in Copenhagen, Coaching at Hvidovre Idrætsforening</li>
     </ul>
   </div>
 
   <div class="section">
     <h2>Skills & Certifications</h2>
     <ul>
-      <li>Languages: Danish (native), English (full professional), French 
-(limited)</li>
-      <li>Training in Linux, cybersecurity, network scanning & 
-surveillance by prof. Jens Myrup at AAU</li>
-      <li>Awards: Winner of Niels Brock’s Stock Competition; participant in 
-Projekt Forskerspirer (UCPH)</li>
+      <li>Languages: Danish (native), English (full professional), French (limited)</li>
+      <li>Training in Linux, cybersecurity, network scanning & surveillance by prof. Jens Myrup at AAU</li>
+      <li>Awards: Winner of Niels Brock’s Stock Competition; participant in Projekt Forskerspirer (UCPH)</li>
     </ul>
   </div>
 
-  <div class="section">
+  <div class="section accent">
     <h2>Contact & Links</h2>
     <ul>
-      <li>Email: <a 
-href="mailto:se.skaarup@gmail.com">se.skaarup@gmail.com</a></li>
-      <li><a href="https://www.linkedin.com/in/s%C3%B8ren-emil-
-skaarup-541557203">LinkedIn Profile</a></li>
+      <li>Email: <a href="mailto:se.skaarup@gmail.com">se.skaarup@gmail.com</a></li>
+      <li><a href="https://www.linkedin.com/in/s%C3%B8ren-emil-skaarup-541557203">LinkedIn Profile</a></li>
     </ul>
   </div>
   <script src="js/nav.js" defer></script>


### PR DESCRIPTION
## Summary
- redesign the homepage with a hero, highlights, and fresh lab updates
- expand the projects page with featured work, demo gallery, and research snapshots
- refresh resume presentation and styling system with new cards, grids, and accent visuals

## Testing
- Not run (not applicable for static content)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69241b05a18c8321864cff52fea06642)