### PR TITLE
Add Claude-generated games hub page

### DIFF
--- a/claude-games.html
+++ b/claude-games.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Søren Emil Skaarup – Claude Games</title>
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+  <h1>Claude-generated Games</h1>
+
+  <!-- Navigation -->
+  <div data-include-nav data-nav-src="partials/nav.html" data-nav-base="."></div>
+
+  <p>
+    A small hub for playful explorations drafted with Claude. Each link below opens an
+    interactive artifact that experiments with history, economics, or ecological
+    systems through simple game mechanics.
+  </p>
+
+  <section class="section">
+    <h2>Play the Experiments</h2>
+    <div class="card-grid">
+      <article class="card">
+        <p class="label">History &amp; Strategy</p>
+        <h3>Earth History Tetris</h3>
+        <p>Stack milestones from Earth's past like Tetris blocks to see how geological
+           and biological eras line up.</p>
+        <a class="button primary" href="https://claude.ai/public/artifacts/dd0cdab1-5061-453b-a536-bcce19898832" target="_blank" rel="noopener">Play Earth History Tetris →</a>
+      </article>
+
+      <article class="card">
+        <p class="label">Science Quiz</p>
+        <h3>Evolution Quiz</h3>
+        <p>Test your instincts on evolutionary turning points with quick questions and
+           instant feedback.</p>
+        <a class="button primary" href="https://claude.ai/public/artifacts/4fc9ce2a-7e7b-4039-bf6b-fe64cd02a006" target="_blank" rel="noopener">Start the Evolution Quiz →</a>
+      </article>
+
+      <article class="card">
+        <p class="label">Economics</p>
+        <h3>Japan vs. Brazil Econ History</h3>
+        <p>Compare trade-offs and policy levers across two economies in a choose-your-path
+           scenario.</p>
+        <a class="button primary" href="https://claude.ai/public/artifacts/d7c9479b-22a8-4369-8363-47877cf4a075" target="_blank" rel="noopener">Explore the Econ History game →</a>
+      </article>
+
+      <article class="card">
+        <p class="label">Demography</p>
+        <h3>Population Aging Analysis</h3>
+        <p>Adjust demographic sliders and see how aging populations reshape budgets and
+           wellbeing metrics.</p>
+        <a class="button primary" href="https://claude.ai/public/artifacts/53a17fd2-b130-4f2f-9840-7a95635bad47" target="_blank" rel="noopener">Run the Aging Analysis →</a>
+      </article>
+
+      <article class="card">
+        <p class="label">Systems</p>
+        <h3>System Dynamics Ecosystem Simulator</h3>
+        <p>Balance resources, species interactions, and random shocks in a lightweight
+           system dynamics sandbox.</p>
+        <a class="button primary" href="https://claude.ai/public/artifacts/9d415cea-f891-44fc-9845-8afb76708266" target="_blank" rel="noopener">Open the Ecosystem Simulator →</a>
+      </article>
+    </div>
+  </section>
+
+  <section class="section accent">
+    <h2>About these games</h2>
+    <p>
+      These prototypes lean on Claude for copy and structure, but they are curated and
+      shared here as conversation starters. Feedback and collaboration ideas are always
+      welcome.
+    </p>
+    <a class="button" href="mailto:se.skaarup@gmail.com">Share your thoughts</a>
+  </section>
+
+  <script src="js/nav.js" defer></script>
+</body>
+</html>

--- a/partials/nav.html
+++ b/partials/nav.html
@@ -2,4 +2,5 @@
   <a href="index.html" data-href="index.html">Home</a>
   <a href="resume.html" data-href="resume.html">Résumé</a>
   <a href="projects.html" data-href="projects.html">Projects</a>
+  <a href="claude-games.html" data-href="claude-games.html">Claude Games</a>
 </nav>


### PR DESCRIPTION
## Summary
- add a new Claude-generated games page highlighting interactive artifacts and links
- update site navigation to include the new page

## Testing
- not run (static content change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924448cae3883219bef68e819a4299c)