### PR TITLE
Add social metadata, canonical links, and favicon to core pages

### DIFF
--- a/claude-games.html
+++ b/claude-games.html
@@ -4,6 +4,18 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Søren Emil Skaarup – Claude Games</title>
+  <meta name="description" content="A collection of Claude-generated games curated by Søren Emil Skaarup, exploring history, economics, and ecological systems through interactive play.">
+  <link rel="canonical" href="https://sorenemilskaarup.com/claude-games.html">
+  <link rel="icon" href="/favicon.ico">
+  <meta property="og:title" content="Søren Emil Skaarup – Claude Games">
+  <meta property="og:description" content="A collection of Claude-generated games curated by Søren Emil Skaarup, exploring history, economics, and ecological systems through interactive play.">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://sorenemilskaarup.com/claude-games.html">
+  <meta property="og:image" content="https://sorenemilskaarup.com/og-image.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Søren Emil Skaarup – Claude Games">
+  <meta name="twitter:description" content="A collection of Claude-generated games curated by Søren Emil Skaarup, exploring history, economics, and ecological systems through interactive play.">
+  <meta name="twitter:image" content="https://sorenemilskaarup.com/og-image.jpg">
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>

--- a/index.html
+++ b/index.html
@@ -4,6 +4,18 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Søren Emil Skaarup – Home</title>
+  <meta name="description" content="Homepage of Søren Emil Skaarup, a researcher exploring human-centered AI, data ethics, and creative simulations with interactive demos and essays.">
+  <link rel="canonical" href="https://sorenemilskaarup.com/">
+  <link rel="icon" href="/favicon.ico">
+  <meta property="og:title" content="Søren Emil Skaarup – Home">
+  <meta property="og:description" content="Homepage of Søren Emil Skaarup, a researcher exploring human-centered AI, data ethics, and creative simulations with interactive demos and essays.">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://sorenemilskaarup.com/">
+  <meta property="og:image" content="https://sorenemilskaarup.com/og-image.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Søren Emil Skaarup – Home">
+  <meta name="twitter:description" content="Homepage of Søren Emil Skaarup, a researcher exploring human-centered AI, data ethics, and creative simulations with interactive demos and essays.">
+  <meta name="twitter:image" content="https://sorenemilskaarup.com/og-image.jpg">
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>

--- a/projects.html
+++ b/projects.html
@@ -4,6 +4,18 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Søren Emil Skaarup – Projects</title>
+  <meta name="description" content="Projects and interactive demos from Søren Emil Skaarup, featuring applied machine learning, data ethics workshops, and playful simulations.">
+  <link rel="canonical" href="https://sorenemilskaarup.com/projects.html">
+  <link rel="icon" href="/favicon.ico">
+  <meta property="og:title" content="Søren Emil Skaarup – Projects">
+  <meta property="og:description" content="Projects and interactive demos from Søren Emil Skaarup, featuring applied machine learning, data ethics workshops, and playful simulations.">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://sorenemilskaarup.com/projects.html">
+  <meta property="og:image" content="https://sorenemilskaarup.com/og-image.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Søren Emil Skaarup – Projects">
+  <meta name="twitter:description" content="Projects and interactive demos from Søren Emil Skaarup, featuring applied machine learning, data ethics workshops, and playful simulations.">
+  <meta name="twitter:image" content="https://sorenemilskaarup.com/og-image.jpg">
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>

--- a/resume.html
+++ b/resume.html
@@ -4,6 +4,18 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Søren Emil Skaarup – Résumé</title>
+  <meta name="description" content="Résumé for Søren Emil Skaarup, highlighting machine learning research, data ethics leadership, and professional experience in Copenhagen.">
+  <link rel="canonical" href="https://sorenemilskaarup.com/resume.html">
+  <link rel="icon" href="/favicon.ico">
+  <meta property="og:title" content="Søren Emil Skaarup – Résumé">
+  <meta property="og:description" content="Résumé for Søren Emil Skaarup, highlighting machine learning research, data ethics leadership, and professional experience in Copenhagen.">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://sorenemilskaarup.com/resume.html">
+  <meta property="og:image" content="https://sorenemilskaarup.com/og-image.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Søren Emil Skaarup – Résumé">
+  <meta name="twitter:description" content="Résumé for Søren Emil Skaarup, highlighting machine learning research, data ethics leadership, and professional experience in Copenhagen.">
+  <meta name="twitter:image" content="https://sorenemilskaarup.com/og-image.jpg">
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>


### PR DESCRIPTION
### Motivation

- Improve how pages appear when shared by adding Open Graph and Twitter card metadata for richer previews.
- Provide page-level `meta description` entries to help search engines display concise summaries.
- Ensure each page has a canonical URL via `link rel="canonical"` to avoid duplicate-content issues.
- Add a placeholder favicon link so an icon can be picked up by browsers once available.

### Description

- Inserted `meta name="description"`, `link rel="canonical"`, and `link rel="icon"` into the `<head>` of `index.html`, `projects.html`, `resume.html`, and `claude-games.html`.
- Added Open Graph tags (`og:title`, `og:description`, `og:type`, `og:url`, `og:image`) and Twitter card tags (`twitter:card`, `twitter:title`, `twitter:description`, `twitter:image`) to each updated head block.
- Tailored the `meta description` and `og`/`twitter` titles/descriptions per page and pointed social images at `https://sorenemilskaarup.com/og-image.jpg` and canonical URLs at `https://sorenemilskaarup.com/...`.
- No layout, script, or content body changes were made beyond the head metadata additions.

### Testing

- No automated tests were run because these are static HTML metadata changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964c17ccd548321ba8a8119604eae11)