### PR TITLE
Add skip-to-content link, main wrappers, and active nav highlighting

### DIFF
--- a/claude-games.html
+++ b/claude-games.html
@@ -7,18 +7,19 @@
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
-  <h1>Claude-generated Games</h1>
-
   <!-- Navigation -->
   <div data-include-nav data-nav-src="partials/nav.html" data-nav-base="."></div>
 
-  <p>
-    A small hub for playful explorations drafted with Claude. Each link below opens an
-    interactive artifact that experiments with history, economics, or ecological
-    systems through simple game mechanics.
-  </p>
+  <main id="main">
+    <h1>Claude-generated Games</h1>
 
-  <section class="section">
+    <p>
+      A small hub for playful explorations drafted with Claude. Each link below opens an
+      interactive artifact that experiments with history, economics, or ecological
+      systems through simple game mechanics.
+    </p>
+
+    <section class="section">
     <h2>Play the Experiments</h2>
     <div class="card-grid">
       <article class="card">
@@ -63,7 +64,7 @@
     </div>
   </section>
 
-  <section class="section accent">
+    <section class="section accent">
     <h2>About these games</h2>
     <p>
       These prototypes lean on Claude for copy and structure, but they are curated and
@@ -71,7 +72,8 @@
       welcome.
     </p>
     <a class="button" href="mailto:se.skaarup@gmail.com">Share your thoughts</a>
-  </section>
+    </section>
+  </main>
 
   <script src="js/nav.js" defer></script>
 </body>

--- a/css/style.css
+++ b/css/style.css
@@ -32,6 +32,31 @@ nav a {
 nav a:hover {
   text-decoration: underline;
 }
+.site-nav a[aria-current="page"] {
+  color: #1f2933;
+  text-decoration: underline;
+  text-underline-offset: 4px;
+  background: #e5edff;
+  border-radius: 6px;
+  padding: 0.1em 0.35em;
+}
+
+.skip-link {
+  position: absolute;
+  top: 0.75em;
+  left: 0.75em;
+  padding: 0.5em 0.9em;
+  background: #1f2933;
+  color: #fff;
+  border-radius: 6px;
+  transform: translateY(-200%);
+  transition: transform 0.2s ease;
+  z-index: 1000;
+}
+.skip-link:focus,
+.skip-link:focus-visible {
+  transform: translateY(0);
+}
 
 /* General links */
 a {

--- a/index.html
+++ b/index.html
@@ -7,12 +7,13 @@
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
-  <h1 class="page-title">Søren Emil Skaarup</h1>
-
   <!-- Navigation -->
   <div data-include-nav data-nav-src="partials/nav.html" data-nav-base="."></div>
 
-  <section class="hero">
+  <main id="main">
+    <h1 class="page-title">Søren Emil Skaarup</h1>
+
+    <section class="hero">
     <div>
       <p class="eyebrow">Machine Learning • Data Ethics • Cognitive Science</p>
       <h2>Researcher exploring human-centered AI and creative simulations.</h2>
@@ -107,7 +108,7 @@
     </div>
   </section>
 
-  <section class="section accent">
+    <section class="section accent">
     <h2>What I'm interested in</h2>
     <div class="grid two-col">
       <div>
@@ -125,7 +126,8 @@
         <a class="button primary" href="mailto:se.skaarup@gmail.com">Start a conversation</a>
       </div>
     </div>
-  </section>
+    </section>
+  </main>
 
   <script src="js/nav.js" defer></script>
 </body>

--- a/js/nav.js
+++ b/js/nav.js
@@ -12,6 +12,8 @@ async function injectNav(placeholder) {
     const nav = placeholder.querySelector('nav');
     if (nav) {
       const normalizedBase = base === '.' ? '' : base.replace(/\/$/, '') + '/';
+      const currentPath = window.location.pathname.replace(/\/$/, '');
+      const currentFile = currentPath.split('/').pop() || 'index.html';
       nav.querySelectorAll('a[data-href]').forEach((link) => {
         const target = link.getAttribute('data-href');
         if (!target) {
@@ -19,6 +21,11 @@ async function injectNav(placeholder) {
         }
         const fullPath = `${normalizedBase}${target}`.replace(/\/\/+/, '/');
         link.setAttribute('href', fullPath);
+        if (target === currentFile) {
+          link.setAttribute('aria-current', 'page');
+        } else {
+          link.removeAttribute('aria-current');
+        }
       });
     }
   } catch (error) {

--- a/partials/nav.html
+++ b/partials/nav.html
@@ -1,3 +1,4 @@
+<a class="skip-link" href="#main">Skip to content</a>
 <nav class="site-nav">
   <a href="index.html" data-href="index.html">Home</a>
   <a href="resume.html" data-href="resume.html">Résumé</a>

--- a/projects.html
+++ b/projects.html
@@ -7,15 +7,16 @@
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
-  <h1>Projects</h1>
-
   <!-- Navigation -->
   <div data-include-nav data-nav-src="partials/nav.html" data-nav-base="."></div>
 
-  <p>This page captures what I'm building and researching. Some items are polished,
-     others are living sketches I iterate on in public.</p>
+  <main id="main">
+    <h1>Projects</h1>
 
-  <section class="section">
+    <p>This page captures what I'm building and researching. Some items are polished,
+       others are living sketches I iterate on in public.</p>
+
+    <section class="section">
     <h2>Feature Projects</h2>
     <div class="card-grid">
       <article class="card">
@@ -103,7 +104,7 @@
     </div>
   </section>
 
-  <section class="section accent">
+    <section class="section accent">
     <h2>Research Snapshots</h2>
     <div class="timeline">
       <div class="timeline-item">
@@ -131,7 +132,8 @@
         </div>
       </div>
     </div>
-  </section>
+    </section>
+  </main>
 
   <script src="js/nav.js" defer></script>
 </body>

--- a/resume.html
+++ b/resume.html
@@ -7,14 +7,15 @@
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
-  <h1 class="page-title">Søren Emil Skaarup</h1>
-
   <!-- Navigation -->
   <div data-include-nav data-nav-src="partials/nav.html" data-nav-base="."></div>
 
-  <p><a href="mailto:se.skaarup@gmail.com">se.skaarup@gmail.com</a> • Copenhagen, Denmark</p>
+  <main id="main">
+    <h1 class="page-title">Søren Emil Skaarup</h1>
 
-  <div class="section">
+    <p><a href="mailto:se.skaarup@gmail.com">se.skaarup@gmail.com</a> • Copenhagen, Denmark</p>
+
+    <div class="section">
     <h2>Professional Summary</h2>
     <p>Research Assistant in Machine Learning at FORCE Technology; associated with the Pioneer Centre for AI. Active in Danish Data Science Academy and Data Ethics Youth Board. Skilled in data analysis, teamwork, and English professional communication.</p>
     <div class="card-grid">
@@ -105,13 +106,14 @@
     </ul>
   </div>
 
-  <div class="section accent">
+    <div class="section accent">
     <h2>Contact & Links</h2>
     <ul>
       <li>Email: <a href="mailto:se.skaarup@gmail.com">se.skaarup@gmail.com</a></li>
       <li><a href="https://www.linkedin.com/in/s%C3%B8ren-emil-skaarup-541557203">LinkedIn Profile</a></li>
     </ul>
-  </div>
+    </div>
+  </main>
   <script src="js/nav.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Improve keyboard accessibility by providing a visible way to jump to the main content via a skip link. 
- Ensure each page has a proper landmark by wrapping primary content in a `main` container with `id="main"` so the skip link target exists. 
- Make the current navigation item programmatically discoverable and visually distinct using `aria-current="page"`. 
- Provide clear styles for the skip link and active nav item in the site stylesheet.

### Description
- Inserted a skip link into the shared navigation partial at `partials/nav.html` (`<a class="skip-link" href="#main">Skip to content</a>`). 
- Wrapped each page's main content in a `<main id="main">...</main>` block on `index.html`, `projects.html`, `resume.html`, and `claude-games.html`. 
- Updated `js/nav.js` to compute the current file from `window.location.pathname` and set or remove `aria-current="page"` on injected nav links. 
- Added CSS rules in `css/style.css` for `.skip-link` (hidden until focus) and `.site-nav a[aria-current="page"]` to provide a clear active state.

### Testing
- Started a local dev server with `python -m http.server 8000` and verified pages served successfully. 
- Ran a Playwright script that opened `http://127.0.0.1:8000/index.html`, sent a `Tab` key to focus the skip link, and captured a screenshot to confirm the skip link appears on focus. 
- Confirmed the injected nav links receive `aria-current="page"` for the matching file when the nav is injected. 
- All automated checks performed (server + Playwright screenshot) completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964c17dca408321a40dcbf43e177181)