### PR TITLE
Add schema.org Person JSON-LD to home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,27 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Søren Emil Skaarup – Home</title>
   <link rel="stylesheet" href="css/style.css">
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Person",
+      "name": "Søren Emil Skaarup",
+      "jobTitle": "Research Assistant",
+      "worksFor": {
+        "@type": "Organization",
+        "name": "FORCE Technology"
+      },
+      "email": "mailto:se.skaarup@gmail.com",
+      "address": {
+        "@type": "PostalAddress",
+        "addressLocality": "Copenhagen",
+        "addressCountry": "Denmark"
+      },
+      "sameAs": [
+        "https://www.linkedin.com/in/s%C3%B8ren-emil-skaarup-541557203"
+      ]
+    }
+  </script>
 </head>
 <body>
   <h1 class="page-title">Søren Emil Skaarup</h1>


### PR DESCRIPTION
### Motivation
- Provide structured `schema.org` metadata for the site owner so search engines and profile aggregators can extract name, role, contact, and profile links.
- Ensure the metadata fields mirror visible content on the site (name, job title, location, email, LinkedIn) as presented in `resume.html` and `index.html`.

### Description
- Inserted a `<script type="application/ld+json">` block into the `<head>` of `index.html` containing a `Person` object with `name`, `jobTitle`, `worksFor`, `email`, `address`, and `sameAs` fields.
- `worksFor` is populated as an `Organization` named `FORCE Technology`, and `address` is a `PostalAddress` with `addressLocality` set to `Copenhagen` and `addressCountry` set to `Denmark` to match the site content.
- The `email` uses a `mailto:` URI and `sameAs` includes the LinkedIn URL present on the résumé page so links remain consistent.

### Testing
- No automated tests were run for this change.
- The updated `index.html` was inspected to confirm the JSON-LD block is present in the document head.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964c181a16c8321b51720b5aae06ac8)