### PR TITLE
Add Updates page and highlight active nav link

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -32,6 +32,11 @@ nav a {
 nav a:hover {
   text-decoration: underline;
 }
+nav a.is-active,
+nav a[aria-current="page"] {
+  text-decoration: underline;
+  color: #0a3d91;
+}
 
 /* General links */
 a {

--- a/js/nav.js
+++ b/js/nav.js
@@ -12,6 +12,7 @@ async function injectNav(placeholder) {
     const nav = placeholder.querySelector('nav');
     if (nav) {
       const normalizedBase = base === '.' ? '' : base.replace(/\/$/, '') + '/';
+      const currentPage = window.location.pathname.split('/').pop() || 'index.html';
       nav.querySelectorAll('a[data-href]').forEach((link) => {
         const target = link.getAttribute('data-href');
         if (!target) {
@@ -19,6 +20,10 @@ async function injectNav(placeholder) {
         }
         const fullPath = `${normalizedBase}${target}`.replace(/\/\/+/, '/');
         link.setAttribute('href', fullPath);
+        if (target === currentPage) {
+          link.setAttribute('aria-current', 'page');
+          link.classList.add('is-active');
+        }
       });
     }
   } catch (error) {

--- a/partials/nav.html
+++ b/partials/nav.html
@@ -2,5 +2,6 @@
   <a href="index.html" data-href="index.html">Home</a>
   <a href="resume.html" data-href="resume.html">Résumé</a>
   <a href="projects.html" data-href="projects.html">Projects</a>
+  <a href="updates.html" data-href="updates.html">Updates</a>
   <a href="claude-games.html" data-href="claude-games.html">Claude Games</a>
 </nav>

--- a/updates.html
+++ b/updates.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Søren Emil Skaarup – Updates</title>
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+  <h1>Updates</h1>
+
+  <!-- Navigation -->
+  <div data-include-nav data-nav-src="partials/nav.html" data-nav-base="."></div>
+
+  <section class="section">
+    <p>A rolling log of recent projects, talks, demos, and essays. I add short notes
+       here as I publish new experiments or share a presentation.</p>
+  </section>
+
+  <section class="section accent">
+    <h2>Recent updates</h2>
+    <div class="timeline">
+      <div class="timeline-item">
+        <div class="dot"></div>
+        <div>
+          <p class="label">Demo • Course — 2024</p>
+          <h3>Statistical intuition mini-course</h3>
+          <p>Short, playful lessons on correlation pitfalls and Bayesian thinking.
+             Built to help newcomers feel the intuition behind the maths.</p>
+          <a href="demos/stat-intuition.html">Open the mini-course →</a>
+        </div>
+      </div>
+      <div class="timeline-item">
+        <div class="dot"></div>
+        <div>
+          <p class="label">Demo — 2024</p>
+          <h3>AI training visualiser</h3>
+          <p>A visual walkthrough of loss curves and sample evolution as a model learns.
+             Designed as a quick explainer for talks and workshops.</p>
+          <a href="demos/ai-training-viz.html">Run the visualiser →</a>
+        </div>
+      </div>
+      <div class="timeline-item">
+        <div class="dot"></div>
+        <div>
+          <p class="label">Project • Simulation — 2024</p>
+          <h3>Entropy Bio-Simulator</h3>
+          <p>A cellular automaton exploring resource competition, randomness, and
+             resilience. Often used as a conversation starter about complex systems.</p>
+          <a href="demos/entropy-bio-simulator.html">Explore the simulator →</a>
+        </div>
+      </div>
+      <div class="timeline-item">
+        <div class="dot"></div>
+        <div>
+          <p class="label">Talk • Workshop — 2023</p>
+          <h3>Data Ethics Workshops</h3>
+          <p>Facilitated sessions on platform incentives, participatory design, and
+             ethical decision-making for data-driven products.</p>
+          <a href="projects.html">See the workshop overview →</a>
+        </div>
+      </div>
+      <div class="timeline-item">
+        <div class="dot"></div>
+        <div>
+          <p class="label">Essay — 2023</p>
+          <h3>Physics essay</h3>
+          <p>A short written exploration of physical intuition and the stories we use
+             to explain complex systems.</p>
+          <a href="demos/physics.html">Read the essay →</a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <script src="js/nav.js" defer></script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide a simple, rolling log for recent projects, talks, demos, and essays so visitors can quickly see what's new.
- Surface the new page in the shared site navigation so it is discoverable from every page.
- Improve navigation UX by indicating the active page in the nav bar.

### Description
- Add a new `updates.html` file with a short introduction and a chronological timeline seeded from existing content (e.g., `demos/stat-intuition.html`, `demos/ai-training-viz.html`, `demos/entropy-bio-simulator.html`).
- Add an `Updates` link to the shared navigation in `partials/nav.html`.
- Update `js/nav.js` to compute the current page and set `aria-current="page"` and the `is-active` class on the matching nav link.
- Add styling for the active nav state in `css/style.css` targeting `nav a.is-active` and `nav a[aria-current="page"]`.

### Testing
- Started a local static server with `python -m http.server 8000` and verified `updates.html` is served successfully.
- Loaded `http://127.0.0.1:8000/updates.html` with Playwright and captured a full-page screenshot to confirm the page renders and navigation injection runs (succeeded).
- No unit tests were added for these static content and small JS changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964c180580c8321b2b49e8aa62aee7b)