### PR TITLE
Add :focus-visible outlines and keyboard focus styles for interactive elements

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -32,6 +32,9 @@ nav a {
 nav a:hover {
   text-decoration: underline;
 }
+nav a:focus-visible {
+  text-decoration: underline;
+}
 
 /* General links */
 a {
@@ -40,6 +43,21 @@ a {
 }
 a:hover {
   text-decoration: underline;
+}
+a:focus-visible {
+  text-decoration: underline;
+}
+
+/* Focus states */
+a:focus-visible,
+button:focus-visible,
+.button:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible,
+summary:focus-visible {
+  outline: 3px solid #3b82f6;
+  outline-offset: 3px;
 }
 
 /* Buttons */
@@ -63,7 +81,8 @@ a:hover {
 .button.ghost {
   background: transparent;
 }
-.button:hover {
+.button:hover,
+.button:focus-visible {
   transform: translateY(-1px);
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
 }


### PR DESCRIPTION
### Motivation
- Improve keyboard accessibility by making focus visible on links, buttons, and form controls so keyboard users can see where focus is.
- Ensure focus styles have sufficient contrast against the page background by using the brand blue as the outline color.
- Mirror hover-only visual effects (transforms and shadows) for keyboard-focused controls so keyboard and mouse users get equivalent affordances.

### Description
- Add `nav a:focus-visible` and `a:focus-visible` rules to show underlines on focused links and match hover behavior.
- Introduce a grouped focus rule for `a`, `button`, `.button`, `input`, `select`, `textarea`, and `summary` that applies `outline: 3px solid #3b82f6` with `outline-offset: 3px`.
- Extend the `.button` hover rule to include `.button:focus-visible` so focused buttons receive the same transform and shadow as hovered buttons.
- All changes are contained in `css/style.css`.

### Testing
- Started a local dev server with `python -m http.server 8000` and ran a Playwright script to open `index.html`, press `Tab`, and capture a screenshot to verify focus outlines visually, which produced `artifacts/focus-visible.png` successfully.
- No unit or integration test suites were present or run for these CSS changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964c17ef14083219decb7db817c3a15)