### PR TITLE
Add learning quizzes subpage with basic physics quiz

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -234,6 +234,42 @@ ul {
   box-shadow: 0 4px 10px rgba(0, 0, 0, 0.03);
 }
 
+/* Quizzes */
+.quiz-list {
+  margin: 0;
+  padding-left: 1.2em;
+  display: grid;
+  gap: 1em;
+}
+.quiz-list li {
+  background: #fff;
+  border: 1px solid #e4e8ef;
+  border-radius: 12px;
+  padding: 1em;
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.04);
+}
+.quiz-list h3 {
+  border: none;
+  padding: 0;
+  margin-top: 0;
+}
+.quiz-prompt {
+  margin-top: 0.2em;
+  margin-bottom: 0.8em;
+}
+.quiz-list details {
+  border-top: 1px dashed #dfe3eb;
+  padding-top: 0.6em;
+}
+.quiz-list summary {
+  cursor: pointer;
+  font-weight: 700;
+  color: #0645AD;
+}
+.quiz-list summary:hover {
+  text-decoration: underline;
+}
+
 /* Timeline */
 .timeline {
   border-left: 3px solid #cdd6ee;

--- a/partials/nav.html
+++ b/partials/nav.html
@@ -3,5 +3,6 @@
   <a href="index.html" data-href="index.html">Home</a>
   <a href="resume.html" data-href="resume.html">Résumé</a>
   <a href="projects.html" data-href="projects.html">Projects</a>
+  <a href="quizzes.html" data-href="quizzes.html">Quizzes</a>
   <a href="claude-games.html" data-href="claude-games.html">Claude Games</a>
 </nav>

--- a/quizzes.html
+++ b/quizzes.html
@@ -1,0 +1,123 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Søren Emil Skaarup – Learning Quizzes</title>
+  <meta name="description" content="Learning quizzes from Søren Emil Skaarup, featuring guided questions and explanations to build intuition through examples.">
+  <link rel="canonical" href="https://sorenemilskaarup.com/quizzes.html">
+  <link rel="icon" href="/favicon.ico">
+  <meta property="og:title" content="Søren Emil Skaarup – Learning Quizzes">
+  <meta property="og:description" content="Learning quizzes from Søren Emil Skaarup, featuring guided questions and explanations to build intuition through examples.">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://sorenemilskaarup.com/quizzes.html">
+  <meta property="og:image" content="https://sorenemilskaarup.com/og-image.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Søren Emil Skaarup – Learning Quizzes">
+  <meta name="twitter:description" content="Learning quizzes from Søren Emil Skaarup, featuring guided questions and explanations to build intuition through examples.">
+  <meta name="twitter:image" content="https://sorenemilskaarup.com/og-image.jpg">
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+  <!-- Navigation -->
+  <div data-include-nav data-nav-src="partials/nav.html" data-nav-base="."></div>
+
+  <main id="main">
+    <h1>Learning Quizzes</h1>
+
+    <p>Short, focused quizzes meant to turn abstract ideas into practical intuition.
+       Each quiz pairs a real-world scenario with a quick explanation, so you can
+       learn by checking your reasoning.</p>
+
+    <section class="section">
+      <h2>How to use these quizzes</h2>
+      <div class="card-grid">
+        <article class="card">
+          <p class="label">Step 1</p>
+          <h3>Read the scenario</h3>
+          <p>Visualize the situation like a lab demo, a sports clip, or a daily task.
+             The examples are designed to anchor the math in something tangible.</p>
+        </article>
+        <article class="card">
+          <p class="label">Step 2</p>
+          <h3>Make a quick estimate</h3>
+          <p>Do a rough mental calculation before peeking at the answer. Estimation
+             builds intuition faster than exact arithmetic alone.</p>
+        </article>
+        <article class="card">
+          <p class="label">Step 3</p>
+          <h3>Compare and reflect</h3>
+          <p>Open the explanation to see the correct reasoning and a reality check.
+             If your answer is close, you are building the right instincts.</p>
+        </article>
+      </div>
+    </section>
+
+    <section class="section">
+      <h2>Quiz: Basic Physics</h2>
+      <p>These questions cover forces, motion, and energy with concrete examples.
+         Reveal each answer to review the calculation and the intuition behind it.</p>
+
+      <ol class="quiz-list">
+        <li>
+          <h3>Force and acceleration</h3>
+          <p class="quiz-prompt">You push a 2 kg shopping cart and it speeds up from rest
+             at 3 m/s². What net force are you applying?</p>
+          <details>
+            <summary>Show answer</summary>
+            <p><strong>Correct:</strong> 6 N.</p>
+            <p>Use Newton's second law: <em>F = m × a</em> → 2 kg × 3 m/s² = 6 N. Think of it
+               as the steady push needed to keep the cart accelerating.</p>
+          </details>
+        </li>
+        <li>
+          <h3>Free fall speed</h3>
+          <p class="quiz-prompt">A ball drops from a balcony 20 meters above the ground (ignore air resistance).
+             About how fast is it moving just before it hits?</p>
+          <details>
+            <summary>Show answer</summary>
+            <p><strong>Correct:</strong> About 20 m/s downward.</p>
+            <p>Use <em>v = √(2gh)</em>. With g ≈ 9.8 m/s² and h = 20 m, v ≈ √(392) ≈ 19.8 m/s.
+               That's roughly the speed of a fast sprint or a 45 mph car.</p>
+          </details>
+        </li>
+        <li>
+          <h3>Braking acceleration</h3>
+          <p class="quiz-prompt">A car slows from 15 m/s to 0 in 5 seconds at a steady rate.
+             What is its acceleration?</p>
+          <details>
+            <summary>Show answer</summary>
+            <p><strong>Correct:</strong> -3 m/s².</p>
+            <p>Acceleration is change in velocity over time: (0 - 15) / 5 = -3 m/s².
+               The negative sign just indicates the car is slowing down.</p>
+          </details>
+        </li>
+        <li>
+          <h3>Energy use</h3>
+          <p class="quiz-prompt">A 60 W lamp runs for 2 hours. How much energy does it consume?</p>
+          <details>
+            <summary>Show answer</summary>
+            <p><strong>Correct:</strong> 0.12 kWh (about 432 kJ).</p>
+            <p>Energy is power × time. 60 W × 2 hours = 120 Wh = 0.12 kWh. In joules,
+               120 Wh × 3600 = 432,000 J.</p>
+          </details>
+        </li>
+        <li>
+          <h3>Momentum change</h3>
+          <p class="quiz-prompt">A 0.2 kg ball moving at 10 m/s is caught and brought to rest.
+             What impulse (change in momentum) does the catcher provide?</p>
+          <details>
+            <summary>Show answer</summary>
+            <p><strong>Correct:</strong> 2 kg·m/s of impulse.</p>
+            <p>Momentum is <em>p = m × v</em>. The ball goes from 0.2 × 10 = 2 kg·m/s to 0,
+               so the impulse is 2 kg·m/s. If the catcher stops it gently, that impulse
+               is spread out over a longer time, reducing the force.</p>
+          </details>
+        </li>
+      </ol>
+    </section>
+  </main>
+
+  <script src="js/nav.js" defer></script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide a new learning-focused subpage that turns physics concepts into quick, example-driven quizzes to build intuition.
- Surface short guided questions and answers suitable for readers to self-check reasoning.
- Integrate the quizzes into the existing site navigation so they are discoverable.

### Description
- Add a new static page `quizzes.html` containing guidance and a "Basic Physics" quiz with five example questions and expandable answers.
- Update the site navigation in `partials/nav.html` to include a `Quizzes` link.
- Add quiz-specific styles to `css/style.css` under a new `.quiz-list` block to match existing site design and interaction patterns.

### Testing
- Started a local server with `python -m http.server 8000`, which successfully served the site during verification.
- Attempted to capture a screenshot with Playwright, but the browser launch crashed and the Playwright run failed. 
- No automated unit or integration tests were run against the new static content.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964e405f0108321af6411e341455b7e)