### PR TITLE
Add guided learning paths and connect demos to next modules

### DIFF
--- a/demos/ai-training-viz.html
+++ b/demos/ai-training-viz.html
@@ -16,6 +16,10 @@
   <canvas id="probCanvas"  style="width:100%;height:200px;"></canvas>
   <pre id="generatedText"></pre>
 
+  <div class="section">
+    <p><strong>Next module:</strong> Continue with the <a href="../quizzes.html#ai-explainability-reflection">AI Explainability reflection prompts</a>.</p>
+  </div>
+
   <script src="../js/nav.js" defer></script>
   <script type="module">
     import { startAIViz } from "../js/demos/modelTrainingDemo.js";

--- a/demos/entropy-bio-simulator.html
+++ b/demos/entropy-bio-simulator.html
@@ -16,6 +16,10 @@
 
   <canvas id="entropySim"></canvas>
 
+  <div class="section">
+    <p><strong>Next module:</strong> Continue with the <a href="../quizzes.html#ethics-simulation-reflection">Ethics &amp; Simulation reflection prompts</a>.</p>
+  </div>
+
   <script src="../js/nav.js" defer></script>
   <script type="module">
     import { startEntropySim } from "../js/demos/entropyBioSimulator.js";

--- a/demos/stat-intuition.html
+++ b/demos/stat-intuition.html
@@ -13,6 +13,10 @@
 
   <div id="statGame"></div>
 
+  <div class="section">
+    <p><strong>Next module:</strong> Continue with the <a href="../quizzes.html#statistical-thinking-quiz">Statistical Thinking reflection and quiz</a>.</p>
+  </div>
+
   <script src="../js/nav.js" defer></script>
   <script src="../js/demos/statIntuitionGame.js"></script>
 </body>

--- a/index.html
+++ b/index.html
@@ -56,6 +56,7 @@
       <div class="cta-row">
         <a class="button primary" href="projects.html">See projects</a>
         <a class="button" href="resume.html">Résumé</a>
+        <a class="button" href="learning-paths.html">Learning paths</a>
         <a class="button ghost" href="mailto:se.skaarup@gmail.com">Email me</a>
       </div>
     </div>
@@ -101,6 +102,7 @@
            micro essays where code and writing meet.</p>
         <ul class="pill-list">
           <li><a href="projects.html#demos">Demo gallery</a></li>
+          <li><a href="learning-paths.html">Guided learning paths</a></li>
           <li><a href="demos/ai-training-viz.html">AI training viz</a></li>
           <li><a href="demos/entropy-bio-simulator.html">Entropy automaton</a></li>
         </ul>

--- a/learning-paths.html
+++ b/learning-paths.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Søren Emil Skaarup – Learning Paths</title>
+  <meta name="description" content="Structured learning paths that combine readings, interactive demos, and reflection prompts across statistics, AI explainability, and ethics simulation.">
+  <link rel="canonical" href="https://sorenemilskaarup.com/learning-paths.html">
+  <link rel="icon" href="/favicon.ico">
+  <meta property="og:title" content="Søren Emil Skaarup – Learning Paths">
+  <meta property="og:description" content="Follow guided tracks in Statistical Thinking, AI Explainability, and Ethics & Simulation.">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://sorenemilskaarup.com/learning-paths.html">
+  <meta property="og:image" content="https://sorenemilskaarup.com/og-image.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Søren Emil Skaarup – Learning Paths">
+  <meta name="twitter:description" content="Guided modules with readings, demos, quizzes, and optional deep dives.">
+  <meta name="twitter:image" content="https://sorenemilskaarup.com/og-image.jpg">
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+  <div data-include-nav data-nav-src="partials/nav.html" data-nav-base="."></div>
+
+  <main id="main">
+    <h1>Learning Paths</h1>
+    <p>Pick a track and move step-by-step from context to interaction, then consolidate your understanding with a short quiz or reflection prompt.</p>
+
+    <section class="section" id="statistical-thinking-track">
+      <h2>Track 1: Statistical Thinking</h2>
+      <ol class="stacked-list">
+        <li><strong>Intro reading:</strong> <a href="projects.html">Project context and goals</a></li>
+        <li><strong>Demo:</strong> <a href="demos/stat-intuition.html">Statistical Intuition Game</a></li>
+        <li><strong>Quiz/reflection:</strong> <a href="quizzes.html#statistical-thinking-quiz">Statistical Thinking reflection prompts</a></li>
+        <li><strong>Optional advanced resource:</strong> <a href="demos/physics.html">Physics Fundamentals essay</a></li>
+      </ol>
+    </section>
+
+    <section class="section" id="ai-explainability-track">
+      <h2>Track 2: AI Explainability</h2>
+      <ol class="stacked-list">
+        <li><strong>Intro reading:</strong> <a href="projects.html#demos">Interactive demo overview</a></li>
+        <li><strong>Demo:</strong> <a href="demos/ai-training-viz.html">AI Training &amp; Inference Demo</a></li>
+        <li><strong>Quiz/reflection:</strong> <a href="quizzes.html#ai-explainability-reflection">AI Explainability reflection prompts</a></li>
+        <li><strong>Optional advanced resource:</strong> <a href="demos/Natural_History.html">Natural History and entropy essay</a></li>
+      </ol>
+    </section>
+
+    <section class="section" id="ethics-simulation-track">
+      <h2>Track 3: Ethics &amp; Simulation</h2>
+      <ol class="stacked-list">
+        <li><strong>Intro reading:</strong> <a href="projects.html">Data ethics workshop themes</a></li>
+        <li><strong>Demo:</strong> <a href="demos/entropy-bio-simulator.html">Entropy Bio-Simulator</a></li>
+        <li><strong>Quiz/reflection:</strong> <a href="quizzes.html#ethics-simulation-reflection">Ethics &amp; Simulation reflection prompts</a></li>
+        <li><strong>Optional advanced resource:</strong> <a href="demos/nitrogen-cycle.html">Nitrogen Cycle visualizer</a></li>
+      </ol>
+    </section>
+  </main>
+
+  <script src="js/nav.js" defer></script>
+</body>
+</html>

--- a/quizzes.html
+++ b/quizzes.html
@@ -53,7 +53,15 @@
       </div>
     </section>
 
-    <section class="section">
+
+
+    <section class="section accent">
+      <h2>Prefer a guided sequence?</h2>
+      <p>These quizzes now map into dedicated tracks so you can move from reading to demo to reflection in order.</p>
+      <a class="button primary" href="learning-paths.html">Open learning paths</a>
+    </section>
+
+    <section class="section" id="statistical-thinking-quiz">
       <h2>Quiz: Basic Physics</h2>
       <p>These questions cover forces, motion, and energy with concrete examples.
          Reveal each answer to review the calculation and the intuition behind it.</p>
@@ -116,6 +124,26 @@
         </li>
       </ol>
     </section>
+
+
+    <section class="section" id="ai-explainability-reflection">
+      <h2>Reflection: AI Explainability</h2>
+      <ol class="quiz-list">
+        <li>Which part of the training curve felt most interpretable, and why?</li>
+        <li>How would you explain sampling uncertainty to a non-technical stakeholder?</li>
+        <li>What one extra metric would improve trust in this demo's outputs?</li>
+      </ol>
+    </section>
+
+    <section class="section" id="ethics-simulation-reflection">
+      <h2>Reflection: Ethics &amp; Simulation</h2>
+      <ol class="quiz-list">
+        <li>Which design choice in a simulation can most strongly bias user conclusions?</li>
+        <li>How would you communicate the limits of a toy model before policy discussion?</li>
+        <li>Name one real-world variable missing from the simulation that could change outcomes.</li>
+      </ol>
+    </section>
+
   </main>
 
   <script src="js/nav.js" defer></script>


### PR DESCRIPTION
### Motivation
- Provide a simple, opinionated way for visitors to follow curated sequences from reading → demo → reflection so learning flows coherently across existing content.

### Description
- Add a new `learning-paths.html` page with three tracks: Statistical Thinking, AI Explainability, and Ethics & Simulation, each listing ordered modules for intro reading, demo, quiz/reflection, and an optional advanced resource.
- Update `index.html` to surface the new learning paths from the hero CTA row and the highlights/demo area by adding links to `learning-paths.html`.
- Update `quizzes.html` to include a guided-sequence callout linking to the learning paths, add a stable anchor for the existing quiz section, and add two new reflection sections (`ai-explainability-reflection` and `ethics-simulation-reflection`) referenced by the tracks.
- Add “Next module” links to the bottom of the relevant demo pages: `demos/stat-intuition.html`, `demos/ai-training-viz.html`, and `demos/entropy-bio-simulator.html` that point into the new reflection anchors on `quizzes.html`.

### Testing
- Ran `git diff --check` to validate whitespace/merge issues and it succeeded.
- Launched a local static server (`python3 -m http.server 8000`) and captured a screenshot of `http://127.0.0.1:8000/learning-paths.html` for visual confirmation, which completed successfully.
- Attempted `python3 -m py_compile js/nav.js` (mistakenly targeting a JavaScript file) which failed; this failure is expected because `py_compile` is for Python files and does not indicate any issue with the HTML/JS changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699317768f1483218a68e968e98a5a0b)