### PR TITLE
Add topic tags and "Related content" blocks; introduce compact tag pill style

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -220,6 +220,31 @@ ul {
   font-size: 0.9rem;
   color: #1f2a44;
 }
+
+.topic-tags {
+  list-style: none;
+  padding: 0;
+  margin: 0.6em 0 0 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35em;
+}
+
+.topic-tags li {
+  margin: 0;
+}
+
+.topic-tag {
+  display: inline-block;
+  padding: 0.15em 0.55em;
+  border-radius: 999px;
+  border: 1px solid #b8c5df;
+  background: #f8faff;
+  color: #39527e;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+}
 .stacked-list {
   list-style: none;
   padding: 0;

--- a/demos/Natural_History.html
+++ b/demos/Natural_History.html
@@ -16,6 +16,15 @@
 
   <h1>Evolutionary History and the Flow of Entropy</h1>
 
+  <ul class="topic-tags" aria-label="Topics">
+    <li><span class="topic-tag">#ethics</span></li>
+    <li><span class="topic-tag">#simulation</span></li>
+    <li><span class="topic-tag">#ml</span></li>
+  </ul>
+
+  <p>Continue with the <a href="../demos/entropy-bio-simulator.html">Entropy Bio-Simulator</a> or browse all
+     connected work on the <a href="../projects.html">projects page</a>.</p>
+
   <section>
     <p>
       Life on Earth is a local expression of thermodynamic imbalance. We harvest low-entropy energy from the Sun—photons in ordered, high-frequency states—and transform it into temporary structures of biological complexity. These fragile structures, such as cells, tissues, and organisms, persist only so long as they dissipate energy back into the environment in higher-entropy forms, primarily as heat.

--- a/demos/physics.html
+++ b/demos/physics.html
@@ -14,6 +14,15 @@
 
 <h1>Physics Fundamentals</h1>
 
+  <ul class="topic-tags" aria-label="Topics">
+    <li><span class="topic-tag">#physics</span></li>
+    <li><span class="topic-tag">#statistics</span></li>
+    <li><span class="topic-tag">#simulation</span></li>
+  </ul>
+
+  <p>For hands-on practice, open the <a href="../quizzes.html">learning quizzes</a> or jump back to the
+     <a href="../projects.html">projects overview</a> for related demos.</p>
+
   <h2>1. Force</h2>
   <p>According to Newton's Second Law, force is the product of mass and acceleration:</p>
   <div class="formula">F = m × a</div>

--- a/index.html
+++ b/index.html
@@ -160,8 +160,31 @@
       </div>
     </div>
     </section>
-  </main>
 
+  <section class="section">
+    <h2>Related content</h2>
+    <div class="card-grid">
+      <article class="card">
+        <p class="label">Projects</p>
+        <h3>Interactive demos and essays</h3>
+        <p>Browse the full project gallery, including simulations, essays, and live learning tools.</p>
+        <a href="projects.html">Explore projects →</a>
+      </article>
+      <article class="card">
+        <p class="label">Practice</p>
+        <h3>Learning Quizzes</h3>
+        <p>Test your understanding of force, energy, and quantitative reasoning with guided explanations.</p>
+        <a href="quizzes.html">Open quizzes →</a>
+      </article>
+      <article class="card">
+        <p class="label">Read next</p>
+        <h3>Natural History essay</h3>
+        <p>Read a systems-level perspective on entropy, evolution, and information flow.</p>
+        <a href="demos/Natural_History.html">Read essay →</a>
+      </article>
+    </div>
+  </section>
+  </main>
   <script src="js/nav.js" defer></script>
 </body>
 </html>

--- a/projects.html
+++ b/projects.html
@@ -42,6 +42,10 @@
           <li>Edge constraints</li>
           <li>Experiment design</li>
         </ul>
+        <ul class="topic-tags" aria-label="Topics">
+          <li><span class="topic-tag">#ml</span></li>
+          <li><span class="topic-tag">#statistics</span></li>
+        </ul>
       </article>
       <article class="card">
         <p class="label">Communication</p>
@@ -54,6 +58,10 @@
           <li>Design for agency</li>
           <li>Participatory methods</li>
         </ul>
+        <ul class="topic-tags" aria-label="Topics">
+          <li><span class="topic-tag">#ethics</span></li>
+          <li><span class="topic-tag">#policy</span></li>
+        </ul>
       </article>
       <article class="card">
         <p class="label">Learning tools</p>
@@ -62,6 +70,10 @@
            Bayesian thinking. Built to make maths feel less intimidating and more
            exploratory.</p>
         <a href="demos/stat-intuition.html">Try the demo →</a>
+        <ul class="topic-tags" aria-label="Topics">
+          <li><span class="topic-tag">#statistics</span></li>
+          <li><span class="topic-tag">#simulation</span></li>
+        </ul>
       </article>
     </div>
   </section>
@@ -107,12 +119,44 @@
         <li>
           <strong>Essay</strong> — Physics
           <a href="demos/physics.html">View →</a>
+          <ul class="topic-tags" aria-label="Topics">
+            <li><span class="topic-tag">#physics</span></li>
+            <li><span class="topic-tag">#statistics</span></li>
+          </ul>
         </li>
         <li>
           <strong>Essay</strong> — Natural History
           <a href="demos/Natural_History.html">View →</a>
+          <ul class="topic-tags" aria-label="Topics">
+            <li><span class="topic-tag">#ethics</span></li>
+            <li><span class="topic-tag">#simulation</span></li>
+          </ul>
         </li>
       </ul>
+    </div>
+  </section>
+
+  <section class="section">
+    <h2>Related content</h2>
+    <div class="card-grid">
+      <article class="card">
+        <p class="label">Deep dive</p>
+        <h3>Learning Quizzes</h3>
+        <p>Reinforce the project ideas with quick problem sets in physics and quantitative reasoning.</p>
+        <a href="quizzes.html">Go to quizzes →</a>
+      </article>
+      <article class="card">
+        <p class="label">Writing</p>
+        <h3>Natural History Essay</h3>
+        <p>A narrative on entropy, complexity, and how energy flow shapes biological systems.</p>
+        <a href="demos/Natural_History.html">Read essay →</a>
+      </article>
+      <article class="card">
+        <p class="label">Overview</p>
+        <h3>Homepage Highlights</h3>
+        <p>Jump back to current focus areas and recent experiments from the front page.</p>
+        <a href="index.html">Visit home →</a>
+      </article>
     </div>
   </section>
 

--- a/quizzes.html
+++ b/quizzes.html
@@ -27,7 +27,9 @@
 
     <p>Short, focused quizzes meant to turn abstract ideas into practical intuition.
        Each quiz pairs a real-world scenario with a quick explanation, so you can
-       learn by checking your reasoning.</p>
+       learn by checking your reasoning. If you want visual walkthroughs first, start with
+       the <a href="projects.html#demos">interactive demos</a> or return to the
+       <a href="index.html">homepage overview</a>.</p>
 
     <section class="section">
       <h2>How to use these quizzes</h2>
@@ -115,6 +117,24 @@
           </details>
         </li>
       </ol>
+    </section>
+
+    <section class="section">
+      <h2>Related content</h2>
+      <ul class="stacked-list">
+        <li>
+          <strong>Statistical Intuition Demo</strong> — Pair these quiz prompts with the playable lesson.
+          <a href="demos/stat-intuition.html">Open demo →</a>
+        </li>
+        <li>
+          <strong>Projects Hub</strong> — Explore simulations and essays connected to these topics.
+          <a href="projects.html">View projects →</a>
+        </li>
+        <li>
+          <strong>Physics Notes</strong> — Review formulas before retaking the quiz.
+          <a href="demos/physics.html">Read notes →</a>
+        </li>
+      </ul>
     </section>
   </main>
 


### PR DESCRIPTION
### Motivation
- Provide lightweight topic metadata (hashtags) for projects and writing to help readers discover related material and surface themes like `#ml`, `#ethics`, and `#simulation`.
- Surface quick navigation paths by adding “Related content” blocks on key pages so sessions naturally deepen across the site.
- Create a small, reusable CSS pattern for compact tag pills that is visually distinct from the existing `.pill-list` chips.

### Description
- Added a compact tagging style with `.topic-tags` and `.topic-tag` in `css/style.css` for hashtag-style pills. 
- Inserted topic tags into `projects.html` feature cards and demo/essay list items, and added topic-tag examples to writing pages `demos/physics.html` and `demos/Natural_History.html` so the pattern is present for future writing pages.
- Added a new “Related content” section to `index.html`, `projects.html`, and `quizzes.html` using existing `card-grid`, `card`, and `stacked-list` components and explicit internal cross-links to increase session depth.
- Ensured each modified key page includes multiple internal links (projects, quizzes, index, and demo pages) to improve navigation.

### Testing
- Served the site locally with `python -m http.server 4173` and verified pages loaded successfully (server run succeeded). 
- Captured a screenshot of the updated `projects.html` using Playwright to validate visual placement of topic tags and the related content block (screenshot produced). 
- Ran a simple `python` script using `re.findall` to count internal `href` values for `index.html`, `projects.html`, and `quizzes.html` which executed successfully and returned internal link counts. 
- Attempted to validate links with `BeautifulSoup` (`bs4`) but that run failed due to `bs4` not being installed in the environment (reason: missing dependency).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69931777f39c8321803cd34d95919a46)