### PR TITLE
Expand README conventions and normalize Natural History demo filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,95 @@
 # website
-Professional Website
+
+Professional website and demo gallery for **sorenemilskaarup.com**.
+
+## File naming conventions
+
+Use consistent, predictable names so links stay stable and easy to scan.
+
+### HTML pages
+- Use **kebab-case** for all page filenames (e.g., `claude-games.html`, `stat-intuition.html`).
+- Keep top-level pages at the repository root (`index.html`, `projects.html`, etc.).
+- Keep demo pages in `demos/` with kebab-case names.
+
+### `demos/` specifics
+- Demo HTML files should follow: `demos/<topic-or-demo-name>.html` in kebab-case.
+- Demo scripts should live in `js/demos/` and use descriptive names (camelCase is acceptable for JS module filenames already in use).
+- When renaming a demo page:
+  1. Add/update internal links (`projects.html`, `index.html`, or other refs).
+  2. Preserve old inbound URLs with a redirect stub when external references may exist.
+  3. Verify navigation still resolves correctly from subdirectories.
+
+## Page metadata checklist
+
+For every public HTML page, include and verify:
+
+- `<title>`
+- `<meta name="description" ...>`
+- `<link rel="canonical" ...>`
+- Open Graph tags:
+  - `<meta property="og:title" ...>`
+  - `<meta property="og:description" ...>`
+  - `<meta property="og:type" ...>`
+  - `<meta property="og:url" ...>`
+  - `<meta property="og:image" ...>`
+- Twitter tags:
+  - `<meta name="twitter:card" ...>`
+  - `<meta name="twitter:title" ...>`
+  - `<meta name="twitter:description" ...>`
+  - `<meta name="twitter:image" ...>`
+
+Recommended workflow:
+1. Copy metadata structure from a fully configured page like `index.html`.
+2. Update title/description/URL values for the specific page.
+3. Confirm canonical and OG URL match the final filename and route.
+
+## CSS: utility class vs component class
+
+Use this rule of thumb when editing `css/style.css`:
+
+### Add a utility class when...
+- The style is a **single-purpose, reusable tweak** (spacing, text alignment, width, display).
+- You expect to reuse it in multiple unrelated components.
+- It composes cleanly without depending on a specific DOM structure.
+
+### Add/extend a component class when...
+- The style belongs to a **specific UI block** (card, nav, hero, quiz panel).
+- It requires multiple coordinated properties.
+- It depends on nested elements, state, or context.
+
+### Avoid
+- Creating one-off utilities that are only used once.
+- Packing global utilities with component-specific assumptions.
+
+## Navigation update checklist
+
+The site uses shared nav injection via `partials/nav.html` + `js/nav.js`.
+
+When changing navigation:
+
+1. **Edit links in `partials/nav.html`**
+   - Maintain both `href` and `data-href` attributes on nav anchors.
+   - `data-href` is the source used by `js/nav.js` for path rewriting.
+
+2. **Verify each page includes nav placeholder correctly**
+   - Root pages should typically use:
+     - `data-nav-src="partials/nav.html"`
+     - `data-nav-base="."`
+   - Pages in `demos/` should typically use:
+     - `data-nav-src="../partials/nav.html"`
+     - `data-nav-base=".."`
+
+3. **Check active-page highlighting**
+   - `js/nav.js` sets `aria-current="page"` based on filename matching.
+   - Confirm renamed files still map to the intended nav item.
+
+4. **Smoke test key routes**
+   - Root pages and at least one demo page.
+   - Ensure nav links resolve to correct absolute/relative targets.
+
+## Rename/redirect policy
+
+If a filename must change for consistency:
+- Prefer the new kebab-case filename.
+- Keep compatibility for the old path via a lightweight redirect page when there may be inbound links.
+- Update internal links to point to the new canonical filename.

--- a/demos/Natural_History.html
+++ b/demos/Natural_History.html
@@ -3,57 +3,14 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Natural History</title>
-  <link rel="stylesheet" href="../css/style.css">
+  <title>Natural History Moved</title>
+  <meta http-equiv="refresh" content="0; url=natural-history.html">
+  <link rel="canonical" href="https://sorenemilskaarup.com/demos/natural-history.html">
+  <script>
+    window.location.replace('natural-history.html');
+  </script>
 </head>
 <body>
-  <h1>Natural History</h1>
-
-  <!-- Navigation -->
-  <div data-include-nav data-nav-src="../partials/nav.html" data-nav-base=".."></div>
-
-
-
-  <h1>Evolutionary History and the Flow of Entropy</h1>
-
-  <section>
-    <p>
-      Life on Earth is a local expression of thermodynamic imbalance. We harvest low-entropy energy from the Sun—photons in ordered, high-frequency states—and transform it into temporary structures of biological complexity. These fragile structures, such as cells, tissues, and organisms, persist only so long as they dissipate energy back into the environment in higher-entropy forms, primarily as heat.
-    </p>
-  </section>
-
-  <section>
-    <h2>From Simplicity to Complexity</h2>
-    <p>
-      Early life began as single-celled organisms. These systems absorbed low-entropy inputs (e.g., sunlight or chemical gradients) and used them to assemble ordered internal states. Through processes like polymerization, simple monomers formed complex polymers—proteins, RNA, and DNA. The emergence of multicellular life represented a further step toward higher-order organization, all fueled by an increasing rate of entropy production.
-    </p>
-    <p>
-      Biological evolution can thus be viewed as a thermodynamic mechanism for channeling energy dissipation through ever more structured—and temporarily ordered—pathways. The complexity we observe is not a defiance of entropy, but a consequence of it: a byproduct of systems optimizing the rate at which they degrade free energy into heat.
-    </p>
-  </section>
-
-  <section>
-    <h2>Entropy, Information, and Memory</h2>
-    <p>
-      Entropy can be interpreted as a loss of information about the system's exact microstate. The heat we release into the environment carries less specific information than the structured molecules that generated it. Over time, this leads to a universe that appears to forget. Macrostates dominate because they can arise from countless microstates.
-    </p>
-    <p>
-      This view contrasts sharply with certain interpretations of quantum mechanics. In particular, the principle of unitarity in quantum theory suggests that information is never lost. When a quantum system is observed, the Schrödinger wave function appears to "collapse" (as per Heisenberg's uncertainty principle), but theoretically the underlying information is preserved. This tension—between classical thermodynamic irreversibility and quantum informational conservation—remains one of the deepest puzzles in modern physics.
-    </p>
-  </section>
-
-  <section>
-    <h2>Paths of Least Resistance and the Principle of Least Action</h2>
-    <p>
-      The natural evolution of physical systems often follows the path of least action, as described by the Lagrangian formulation in physics. In this view, systems evolve along trajectories that minimize (or extremize) the difference between kinetic and potential energy over time.
-    </p>
-    <p>
-      In a thermodynamic context, the "least action" may correspond to the most efficient or probable path for entropy production. Identifying the correct Lagrangian in such systems is nontrivial—it must account for not just mechanics, but energy flows, dissipation, and the emergence of order in far-from-equilibrium conditions. Evolution, viewed this way, is not random but constrained by energetic pathways that favor increased entropy, shaped by local gradients and boundary conditions.
-    </p>
-  </section>
-
-
-
-  <script src="../js/nav.js" defer></script>
+  <p>This page has moved to <a href="natural-history.html">natural-history.html</a>.</p>
 </body>
 </html>

--- a/demos/natural-history.html
+++ b/demos/natural-history.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Natural History</title>
+  <link rel="stylesheet" href="../css/style.css">
+</head>
+<body>
+  <h1>Natural History</h1>
+
+  <!-- Navigation -->
+  <div data-include-nav data-nav-src="../partials/nav.html" data-nav-base=".."></div>
+
+
+
+  <h1>Evolutionary History and the Flow of Entropy</h1>
+
+  <section>
+    <p>
+      Life on Earth is a local expression of thermodynamic imbalance. We harvest low-entropy energy from the Sun—photons in ordered, high-frequency states—and transform it into temporary structures of biological complexity. These fragile structures, such as cells, tissues, and organisms, persist only so long as they dissipate energy back into the environment in higher-entropy forms, primarily as heat.
+    </p>
+  </section>
+
+  <section>
+    <h2>From Simplicity to Complexity</h2>
+    <p>
+      Early life began as single-celled organisms. These systems absorbed low-entropy inputs (e.g., sunlight or chemical gradients) and used them to assemble ordered internal states. Through processes like polymerization, simple monomers formed complex polymers—proteins, RNA, and DNA. The emergence of multicellular life represented a further step toward higher-order organization, all fueled by an increasing rate of entropy production.
+    </p>
+    <p>
+      Biological evolution can thus be viewed as a thermodynamic mechanism for channeling energy dissipation through ever more structured—and temporarily ordered—pathways. The complexity we observe is not a defiance of entropy, but a consequence of it: a byproduct of systems optimizing the rate at which they degrade free energy into heat.
+    </p>
+  </section>
+
+  <section>
+    <h2>Entropy, Information, and Memory</h2>
+    <p>
+      Entropy can be interpreted as a loss of information about the system's exact microstate. The heat we release into the environment carries less specific information than the structured molecules that generated it. Over time, this leads to a universe that appears to forget. Macrostates dominate because they can arise from countless microstates.
+    </p>
+    <p>
+      This view contrasts sharply with certain interpretations of quantum mechanics. In particular, the principle of unitarity in quantum theory suggests that information is never lost. When a quantum system is observed, the Schrödinger wave function appears to "collapse" (as per Heisenberg's uncertainty principle), but theoretically the underlying information is preserved. This tension—between classical thermodynamic irreversibility and quantum informational conservation—remains one of the deepest puzzles in modern physics.
+    </p>
+  </section>
+
+  <section>
+    <h2>Paths of Least Resistance and the Principle of Least Action</h2>
+    <p>
+      The natural evolution of physical systems often follows the path of least action, as described by the Lagrangian formulation in physics. In this view, systems evolve along trajectories that minimize (or extremize) the difference between kinetic and potential energy over time.
+    </p>
+    <p>
+      In a thermodynamic context, the "least action" may correspond to the most efficient or probable path for entropy production. Identifying the correct Lagrangian in such systems is nontrivial—it must account for not just mechanics, but energy flows, dissipation, and the emergence of order in far-from-equilibrium conditions. Evolution, viewed this way, is not random but constrained by energetic pathways that favor increased entropy, shaped by local gradients and boundary conditions.
+    </p>
+  </section>
+
+
+
+  <script src="../js/nav.js" defer></script>
+</body>
+</html>

--- a/projects.html
+++ b/projects.html
@@ -110,7 +110,7 @@
         </li>
         <li>
           <strong>Essay</strong> — Natural History
-          <a href="demos/Natural_History.html">View →</a>
+          <a href="demos/natural-history.html">View →</a>
         </li>
       </ul>
     </div>


### PR DESCRIPTION
### Motivation
- Provide clear contributor guidance for file naming, metadata, CSS rules, and navigation so links remain stable and maintainable. 
- Normalize inconsistent demo filenames to kebab-case to avoid broken external links and make the `demos/` folder predictable. 
- Preserve backward compatibility for any external references by keeping redirect stubs for renamed pages. 

### Description
- Expanded `README.md` with sections on file naming conventions (including `demos/`), a page metadata checklist (`title`, `description`, `canonical`, Open Graph, Twitter), guidance for when to add CSS utility vs component classes, and a navigation update checklist covering `partials/nav.html` and `data-nav-base` usage. 
- Added a canonical kebab-case demo page at `demos/natural-history.html` with the original content preserved. 
- Replaced the original `demos/Natural_History.html` with a lightweight redirect page that uses a meta refresh, a JS `location.replace`, and a fallback link to `natural-history.html`. 
- Updated the internal reference in `projects.html` to point to `demos/natural-history.html`. 

### Testing
- Ran a repository search (`rg`) to confirm references to `Natural_History.html` were updated and `demos/natural-history.html` exists. 
- Ran a relative-link resolution check (Python script) for root and `demos/` pages which succeeded for relative targets. 
- Ran a stricter href checker that flagged absolute root and `/favicon.ico` targets as missing, which is an expected artifact of checking absolute paths and is not a regression in these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69931779a90883219ed991e4ea4b5522)